### PR TITLE
Adds trace filtering to trace overview page

### DIFF
--- a/pkg/plugin/search.go
+++ b/pkg/plugin/search.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"net/url"
 	"strconv"
 
 	"github.com/g-research/grafana-incremental-trace-viewer/pkg/opensearch"
@@ -16,7 +17,8 @@ func ptrTo[T any](v T) *T {
 }
 
 func proxySearch(w http.ResponseWriter, datasource *DataSourceInfo, params SearchParams) {
-	url := fmt.Sprintf("%s/api/search?start=%d&end=%d&q=%s", datasource.URL, params.Start, params.End, params.Q)
+	url := fmt.Sprintf("%s/api/search?start=%d&end=%d&q=%s", datasource.URL, params.Start, params.End, url.QueryEscape(params.Q))
+	log.Printf("Proxying tempo search to %s", url)
 	request, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		log.Printf("Failed to create request for tempo search %s: %v", url, err)

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -60,7 +60,7 @@ function TraceOverview() {
       if (!datasource) {
         throw new Error(`Datasource with id ${sourceId} not found`);
       }
-      const q = encodeURIComponent(filters.q || '{}');
+      const q = encodeURIComponent(filters.traceName ? `{name='${filters.traceName}'}` : '{}');
 
       const start = filters.start ? parseInt(filters.start, 10) : new Date().getTime() / 1000;
       const end = filters.end ? parseInt(filters.end, 10) : new Date().getTime() / 1000;
@@ -92,12 +92,12 @@ function TraceOverview() {
     updateFilters({
       start: undefined,
       end: undefined,
-      q: undefined,
+      traceName: undefined,
       datasource: undefined,
     });
   };
 
-  const hasActiveFilters = filters.q || filters.datasource;
+  const hasActiveFilters = filters.traceName || filters.datasource;
 
   const handleTimeRangeChange = (timeRange: TimeRange) => {
     updateFilters({
@@ -164,8 +164,8 @@ function TraceOverview() {
                 {/* Name Filter */}
                 <Field label="Trace Name Filter">
                   <Input
-                    value={filters.q || ''}
-                    onChange={(e) => updateFilters({ q: e.currentTarget.value })}
+                    value={filters.traceName || ''}
+                    onChange={(e) => updateFilters({ traceName: e.currentTarget.value })}
                     placeholder="Filter by trace name..."
                     prefix={<Icon name="search" />}
                   />

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React from 'react';
 import { prefixRoute } from '../utils/utils.routing';
 import { useTraceFilters } from '../utils/utils.url';
 import { BASE_URL, ROUTES } from '../constants';
@@ -45,7 +45,7 @@ function TraceOverview() {
     },
   });
 
-  const [selectedSource, setSelectedSource] = useState<number | null>(null);
+  const selectedSource = filters.datasource ? parseInt(filters.datasource, 10) : null;
 
   const result = useQuery<TempoTrace[]>({
     queryKey: ['datasource', selectedSource, 'traces', filters],
@@ -93,10 +93,11 @@ function TraceOverview() {
       start: undefined,
       end: undefined,
       q: undefined,
+      datasource: undefined,
     });
   };
 
-  const hasActiveFilters = filters.start || filters.end || filters.q;
+  const hasActiveFilters = filters.q || filters.datasource;
 
   const handleTimeRangeChange = (timeRange: TimeRange) => {
     updateFilters({
@@ -131,11 +132,12 @@ function TraceOverview() {
                 <Combobox
                   options={options}
                   placeholder="Select a datasource"
+                  value={selectedSource ? options.find((o) => o.value === selectedSource) : undefined}
                   onChange={(o) => {
                     const datasource = datasources.data.find((d) => d.id === o.value);
                     if (datasource) {
                       queryClient.setQueryData<datasource[]>(['datasource', o.value], datasources.data, {});
-                      setSelectedSource(o.value);
+                      updateFilters({ datasource: o.value.toString() });
                     }
                   }}
                 />
@@ -205,11 +207,11 @@ function TraceOverview() {
                   {result.data.map((r) => {
                     return (
                       <Link key={r.traceID} to={prefixRoute(`${selectedSource}/${ROUTES.TraceDetails}/${r.traceID}`)}>
-                        <li className="p-3 hover:bg-gray-50 transition-colors">
+                        <li className="p-3 hover:bg-gray-500 transition-colors">
                           <div className="flex items-center justify-between">
                             <div>
                               <span className="font-medium">
-                                {r.rootTraceName}({r.rootServiceName})
+                                {r.rootTraceName} ({r.rootServiceName})
                               </span>
                             </div>
                             {r.startTime && (

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -61,8 +61,10 @@ function TraceOverview() {
         throw new Error(`Datasource with id ${sourceId} not found`);
       }
       const q = encodeURIComponent(filters.q || '{}');
-      const start = Math.floor(new Date(filters.start || '').getTime() / 1000);
-      const end = Math.floor(new Date(filters.end || '').getTime() / 1000);
+
+      const start = filters.start ? parseInt(filters.start, 10) : new Date().getTime() / 1000;
+      const end = filters.end ? parseInt(filters.end, 10) : new Date().getTime() / 1000;
+
       const response = getBackendSrv().fetch<SearchResponse>({
         url: `${BASE_URL}${ApiPaths.search}?q=${q}&start=${start}&end=${end}`,
         method: 'POST',
@@ -104,8 +106,8 @@ function TraceOverview() {
   };
 
   const getTimeRangeValue = (): TimeRange => {
-    const from = filters.start ? dateTime(parseInt(filters.start, 10)) : dateTime().subtract(1, 'hour');
-    const to = filters.end ? dateTime(parseInt(filters.end, 10)) : dateTime();
+    const from = filters.start ? dateTime(parseInt(filters.start, 10) * 1000) : dateTime().subtract(1, 'hour');
+    const to = filters.end ? dateTime(parseInt(filters.end, 10) * 1000) : dateTime();
     return {
       from,
       to,
@@ -203,7 +205,7 @@ function TraceOverview() {
                   {result.data.map((r) => {
                     return (
                       <Link key={r.traceID} to={prefixRoute(`${selectedSource}/${ROUTES.TraceDetails}/${r.traceID}`)}>
-                        <li className="p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                        <li className="p-3 hover:bg-gray-50 transition-colors">
                           <div className="flex items-center justify-between">
                             <div>
                               <span className="font-medium">

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -98,14 +98,14 @@ function TraceOverview() {
 
   const handleTimeRangeChange = (timeRange: TimeRange) => {
     updateFilters({
-      start: timeRange.from.toISOString(),
-      end: timeRange.to.toISOString(),
+      start: timeRange.from.unix().toString(),
+      end: timeRange.to.unix().toString(),
     });
   };
 
   const getTimeRangeValue = (): TimeRange => {
-    const from = filters.start ? dateTime(filters.start) : dateTime().subtract(1, 'hour');
-    const to = filters.end ? dateTime(filters.end) : dateTime();
+    const from = filters.start ? dateTime(parseInt(filters.start, 10)) : dateTime().subtract(1, 'hour');
+    const to = filters.end ? dateTime(parseInt(filters.end, 10)) : dateTime();
     return {
       from,
       to,

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -1,10 +1,12 @@
 import React, { useState } from 'react';
 import { prefixRoute } from '../utils/utils.routing';
+import { useTraceFilters } from '../utils/utils.url';
 import { BASE_URL, ROUTES } from '../constants';
 import { testIds } from '../components/testIds';
 import { lastValueFrom } from 'rxjs';
 import { PluginPage, getBackendSrv } from '@grafana/runtime';
-import { Combobox } from '@grafana/ui';
+import { Combobox, Input, Field, Stack, Button, Icon, TimeRangeInput } from '@grafana/ui';
+import { dateTime, TimeRange } from '@grafana/data';
 import { Link } from 'react-router-dom';
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { type components, ApiPaths } from '../schema.gen';
@@ -29,6 +31,8 @@ type TempoTrace = components['schemas']['TempoTrace'];
 
 function TraceOverview() {
   const queryClient = useQueryClient();
+  const [filters, updateFilters] = useTraceFilters();
+
   const datasources = useSuspenseQuery<datasource[]>({
     queryKey: ['datasources'],
     queryFn: async () => {
@@ -44,7 +48,7 @@ function TraceOverview() {
   const [selectedSource, setSelectedSource] = useState<number | null>(null);
 
   const result = useQuery<TempoTrace[]>({
-    queryKey: ['datasource', selectedSource, 'traces'],
+    queryKey: ['datasource', selectedSource, 'traces', filters],
     queryFn: async ({ queryKey }) => {
       const sourceId = queryKey[1];
 
@@ -56,10 +60,9 @@ function TraceOverview() {
       if (!datasource) {
         throw new Error(`Datasource with id ${sourceId} not found`);
       }
-      const q = encodeURIComponent('{}');
-      const oneWeek = 604800;
-      const start = Math.floor(Date.now() / 1000) - oneWeek;
-      const end = Math.floor(Date.now() / 1000);
+      const q = encodeURIComponent(filters.q || '{}');
+      const start = Math.floor(new Date(filters.start || '').getTime() / 1000);
+      const end = Math.floor(new Date(filters.end || '').getTime() / 1000);
       const response = getBackendSrv().fetch<SearchResponse>({
         url: `${BASE_URL}${ApiPaths.search}?q=${q}&start=${start}&end=${end}`,
         method: 'POST',
@@ -83,38 +86,143 @@ function TraceOverview() {
     };
   });
 
+  const handleClearFilters = () => {
+    updateFilters({
+      start: undefined,
+      end: undefined,
+      q: undefined,
+    });
+  };
+
+  const hasActiveFilters = filters.start || filters.end || filters.q;
+
+  const handleTimeRangeChange = (timeRange: TimeRange) => {
+    updateFilters({
+      start: timeRange.from.toISOString(),
+      end: timeRange.to.toISOString(),
+    });
+  };
+
+  const getTimeRangeValue = (): TimeRange => {
+    const from = filters.start ? dateTime(filters.start) : dateTime().subtract(1, 'hour');
+    const to = filters.end ? dateTime(filters.end) : dateTime();
+    return {
+      from,
+      to,
+      raw: {
+        from: from.toISOString(),
+        to: to.toISOString(),
+      },
+    };
+  };
+
   return (
     <PluginPage>
       <div data-testid={testIds.pageOne.container}>
-        This is the trace overview page. We would need to add filters here ourselves.
-        <div className="py-8">
-          <Combobox
-            options={options}
-            placeholder="Select a datasource"
-            onChange={(o) => {
-              const datasource = datasources.data.find((d) => d.id === o.value);
-              if (datasource) {
-                queryClient.setQueryData<datasource[]>(['datasource', o.value], datasources.data, {});
-                setSelectedSource(o.value);
-              }
-            }}
-          />
+        <div className="mb-6">
+          <h2 className="text-xl font-semibold mb-4">Trace Overview</h2>
+
+          <Stack direction="column">
+            {/* Datasource Selection */}
+            <div className="mb-6">
+              <Field label="Datasource">
+                <Combobox
+                  options={options}
+                  placeholder="Select a datasource"
+                  onChange={(o) => {
+                    const datasource = datasources.data.find((d) => d.id === o.value);
+                    if (datasource) {
+                      queryClient.setQueryData<datasource[]>(['datasource', o.value], datasources.data, {});
+                      setSelectedSource(o.value);
+                    }
+                  }}
+                />
+              </Field>
+            </div>
+
+            {/* Filters */}
+            <div className="mb-6">
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-medium">Filters</h3>
+                {hasActiveFilters && (
+                  <Button variant="secondary" size="sm" onClick={handleClearFilters} icon="times">
+                    Clear Filters
+                  </Button>
+                )}
+              </div>
+
+              <Stack direction="row">
+                {/* Time Range Filter */}
+                <Field label="Time Range">
+                  <TimeRangeInput value={getTimeRangeValue()} onChange={handleTimeRangeChange} showIcon />
+                </Field>
+
+                {/* Name Filter */}
+                <Field label="Trace Name Filter">
+                  <Input
+                    value={filters.q || ''}
+                    onChange={(e) => updateFilters({ q: e.currentTarget.value })}
+                    placeholder="Filter by trace name..."
+                    prefix={<Icon name="search" />}
+                  />
+                </Field>
+              </Stack>
+            </div>
+          </Stack>
+          {/* Results */}
+          {result.isLoading && (
+            <div className="text-center py-8">
+              <Icon name="spinner" className="animate-spin text-2xl" />
+              <p className="mt-2">Loading traces...</p>
+            </div>
+          )}
+
+          {result.isError && (
+            <div className="text-center py-8 text-red-600">
+              <Icon name="exclamation-triangle" className="text-2xl" />
+              <p className="mt-2">Error loading traces: {result.error?.message}</p>
+            </div>
+          )}
+
+          {result.isSuccess && (
+            <div>
+              <div className="flex items-center justify-between mb-4">
+                <h3 className="text-lg font-medium">Traces</h3>
+                <span className="text-sm text-gray-500">
+                  {result.data.length} trace{result.data.length !== 1 ? 's' : ''} found
+                </span>
+              </div>
+
+              {result.data.length === 0 ? (
+                <div className="text-center py-8 text-gray-500">
+                  <Icon name="info-circle" className="text-2xl" />
+                  <p className="mt-2">No traces found matching the current filters</p>
+                </div>
+              ) : (
+                <ul className="space-y-2">
+                  {result.data.map((r) => {
+                    return (
+                      <Link key={r.traceID} to={prefixRoute(`${selectedSource}/${ROUTES.TraceDetails}/${r.traceID}`)}>
+                        <li className="p-3 border border-gray-200 rounded-lg hover:bg-gray-50 transition-colors">
+                          <div className="flex items-center justify-between">
+                            <div>
+                              <span className="font-medium">
+                                {r.rootTraceName}({r.rootServiceName})
+                              </span>
+                            </div>
+                            {r.startTime && (
+                              <div className="text-sm text-gray-500">{new Date(r.startTime).toLocaleString()}</div>
+                            )}
+                          </div>
+                        </li>
+                      </Link>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          )}
         </div>
-        {result.isSuccess && result.data.length > 0 && (
-          <ul className="p-4">
-            {result.data.map((r) => {
-              return (
-                <>
-                  <Link key={r.traceID} to={prefixRoute(`${selectedSource}/${ROUTES.TraceDetails}/${r.traceID}`)}>
-                    <li>
-                      {r.rootTraceName} ({r.rootServiceName})
-                    </li>
-                  </Link>
-                </>
-              );
-            })}
-          </ul>
-        )}
       </div>
     </PluginPage>
   );

--- a/src/styles/tailwind.css
+++ b/src/styles/tailwind.css
@@ -1,1 +1,16 @@
 @import 'tailwindcss';
+
+/* Some custom style to hide parts of the query editor */
+.query-editor {
+  & > div:last-child {
+    /* hide query type selection */
+    > div > div:first-child {
+      display: none;
+    }
+
+    /* hide search options */
+    > div > div:last-child {
+      display: none;
+    }
+  }
+}

--- a/src/utils/utils.url.ts
+++ b/src/utils/utils.url.ts
@@ -1,0 +1,33 @@
+import { useSearchParams } from 'react-router-dom';
+
+export interface TraceFilters {
+  start?: string;
+  end?: string;
+  q?: string;
+}
+
+export function useTraceFilters(): [TraceFilters, (filters: Partial<TraceFilters>) => void] {
+  const [searchParams, setSearchParams] = useSearchParams();
+
+  const filters: TraceFilters = {
+    start: searchParams.get('start') || undefined,
+    end: searchParams.get('end') || undefined,
+    q: searchParams.get('q') || undefined,
+  };
+
+  const updateFilters = (newFilters: Partial<TraceFilters>) => {
+    const updatedParams = new URLSearchParams(searchParams);
+
+    Object.entries(newFilters).forEach(([key, value]) => {
+      if (value === undefined || value === '') {
+        updatedParams.delete(key);
+      } else {
+        updatedParams.set(key, value);
+      }
+    });
+
+    setSearchParams(updatedParams, { replace: true });
+  };
+
+  return [filters, updateFilters];
+}

--- a/src/utils/utils.url.ts
+++ b/src/utils/utils.url.ts
@@ -6,13 +6,25 @@ export interface TraceFilters {
   q?: string;
 }
 
+const ONE_WEEK = 604800;
+
+const defaultFilters = (): TraceFilters => {
+  const start = Math.floor(Date.now() / 1000) - ONE_WEEK;
+  const end = Math.floor(Date.now() / 1000);
+  return {
+    start: start.toString(),
+    end: end.toString(),
+    q: undefined,
+  };
+};
+
 export function useTraceFilters(): [TraceFilters, (filters: Partial<TraceFilters>) => void] {
   const [searchParams, setSearchParams] = useSearchParams();
 
   const filters: TraceFilters = {
-    start: searchParams.get('start') || undefined,
-    end: searchParams.get('end') || undefined,
-    q: searchParams.get('q') || undefined,
+    start: searchParams.get('start') || defaultFilters().start,
+    end: searchParams.get('end') || defaultFilters().end,
+    q: searchParams.get('q') || defaultFilters().q,
   };
 
   const updateFilters = (newFilters: Partial<TraceFilters>) => {

--- a/src/utils/utils.url.ts
+++ b/src/utils/utils.url.ts
@@ -4,6 +4,7 @@ export interface TraceFilters {
   start?: string;
   end?: string;
   q?: string;
+  datasource?: string;
 }
 
 const ONE_WEEK = 604800;
@@ -25,6 +26,7 @@ export function useTraceFilters(): [TraceFilters, (filters: Partial<TraceFilters
     start: searchParams.get('start') || defaultFilters().start,
     end: searchParams.get('end') || defaultFilters().end,
     q: searchParams.get('q') || defaultFilters().q,
+    datasource: searchParams.get('datasource') || undefined,
   };
 
   const updateFilters = (newFilters: Partial<TraceFilters>) => {

--- a/src/utils/utils.url.ts
+++ b/src/utils/utils.url.ts
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 export interface TraceFilters {
   start?: string;
   end?: string;
-  q?: string;
+  traceName?: string;
   datasource?: string;
 }
 
@@ -15,7 +15,7 @@ const defaultFilters = (): TraceFilters => {
   return {
     start: start.toString(),
     end: end.toString(),
-    q: undefined,
+    traceName: undefined,
   };
 };
 
@@ -25,7 +25,7 @@ export function useTraceFilters(): [TraceFilters, (filters: Partial<TraceFilters
   const filters: TraceFilters = {
     start: searchParams.get('start') || defaultFilters().start,
     end: searchParams.get('end') || defaultFilters().end,
-    q: searchParams.get('q') || defaultFilters().q,
+    traceName: searchParams.get('traceName') || defaultFilters().traceName,
     datasource: searchParams.get('datasource') || undefined,
   };
 

--- a/src/utils/utils.url.ts
+++ b/src/utils/utils.url.ts
@@ -3,7 +3,7 @@ import { useSearchParams } from 'react-router-dom';
 export interface TraceFilters {
   start?: string;
   end?: string;
-  traceName?: string;
+  query?: string;
   datasource?: string;
 }
 
@@ -15,7 +15,7 @@ const defaultFilters = (): TraceFilters => {
   return {
     start: start.toString(),
     end: end.toString(),
-    traceName: undefined,
+    query: undefined,
   };
 };
 
@@ -25,7 +25,7 @@ export function useTraceFilters(): [TraceFilters, (filters: Partial<TraceFilters
   const filters: TraceFilters = {
     start: searchParams.get('start') || defaultFilters().start,
     end: searchParams.get('end') || defaultFilters().end,
-    traceName: searchParams.get('traceName') || defaultFilters().traceName,
+    query: searchParams.get('query') || defaultFilters().query,
     datasource: searchParams.get('datasource') || undefined,
   };
 


### PR DESCRIPTION
Implements filtering functionality on the trace overview page.

Introduces time range and trace name filters, allowing users to narrow down trace results.
Persists filter selections in the URL, enabling shareable and bookmarkable filtered views.