### PR TITLE
Simplify Tempo API extension

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -60,39 +60,19 @@ paths:
           schema:
             type: integer # unix epoch seconds
           in: query
-        - name: depth
-          description: |
-            The depth of the query.
-            If not provided, the default depth will be used.
-          schema:
-            type: integer
-          in: query
-        - name: childrenLimit
-          description: |
-            The maximum number of children to fetch on each level.
-          schema:
-            type: integer
-          in: query
+        # - name: depth # TODO: to -1 all, 0 none, 1 next level.
+        #   description: |
+        #     The depth of the query.
+        #     If not provided, the default depth will be used.
+        #   schema:
+        #     type: integer
+        #   in: query
         - name: spanId
           description: |
             The parent span id to start the query from.
             If not provided, the root span will be used.
           schema:
             type: string
-          in: query
-        - name: skip
-          description: |
-            The number of spans to skip.
-            Should only be used in combination with spanId.
-          schema:
-            type: integer
-          in: query
-        - name: take
-          description: |
-            The number of spans to take.
-            Should only be used in combination with spanId.
-          schema:
-            type: integer
           in: query
       requestBody:
         content:
@@ -105,7 +85,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: '#/components/schemas/TracesData'
+                $ref: '#/components/schemas/TraceDetailResponse'
 
 components:
   schemas:
@@ -248,17 +228,9 @@ components:
       type: object
       properties:
         traceId:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
+          type: string
         spanId:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
+          type: string
         traceState:
           type: string
           nullable: true
@@ -328,25 +300,14 @@ components:
       type: object
       properties:
         traceId:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
-        spanID:
-          type: array
-          items:
-            type: integer
-            format: int32
-          nullable: true
+          type: string
+        spanId:
+          type: string
         traceState:
           type: string
           nullable: true
         parentSpanId:
-          type: array
-          items:
-            type: integer
-            format: int32
+          type: string
           nullable: true
         flags:
           type: integer
@@ -491,11 +452,6 @@ components:
         duration:
           type: string
           format: date-span
-        spanSets:
-          type: array
-          items:
-            $ref: '#/components/schemas/SpanSet'
-          nullable: true
       additionalProperties: false
     TempoV1Response:
       type: object
@@ -539,15 +495,21 @@ components:
             $ref: '#/components/schemas/TagValue'
           nullable: true
       additionalProperties: false
-    TracesData:
+    TraceDetail:
       type: object
       properties:
         resourceSpans:
           type: array
           items:
             $ref: '#/components/schemas/ResourceSpans'
-          nullable: true
+          nullable: false
           readOnly: true
+      additionalProperties: false
+    TraceDetailResponse:
+      type: object
+      properties:
+        trace:
+          $ref: '#/components/schemas/TraceDetail'
       additionalProperties: false
     ValueOneofCase:
       enum:

--- a/pkg/plugin/trace.go
+++ b/pkg/plugin/trace.go
@@ -62,22 +62,6 @@ func convertKeyValues(keyValues map[string]interface{}) []KeyValue {
 	return kv
 }
 
-func convertIdToBytes(id string) []int32 {
-	bytes := make([]int32, 0, len(id))
-	for _, c := range id {
-		bytes = append(bytes, int32(c))
-	}
-	return bytes
-}
-
-func convertBytesToId(bytes []int32) string {
-	runes := make([]rune, 0, len(bytes))
-	for _, b := range bytes {
-		runes = append(runes, rune(b))
-	}
-	return string(runes)
-}
-
 func convertHitToSpan(hit opensearch.Hit) Span {
 	spanAttributes := make([]KeyValue, 0, len(hit.Source.Attributes))
 	for k, v := range hit.Source.Attributes {
@@ -101,8 +85,8 @@ func convertHitToSpan(hit opensearch.Hit) Span {
 		links = append(links, Link{
 			Attributes:             ptrTo(linkAttributes),
 			DroppedAttributesCount: ptrTo(int32(link.DroppedAttributesCount)),
-			TraceID:                ptrTo(convertIdToBytes(link.TraceID)),
-			SpanID:                 ptrTo(convertIdToBytes(link.SpanID)),
+			TraceID:                ptrTo(link.TraceID),
+			SpanID:                 ptrTo(link.SpanID),
 			TraceState:             ptrTo(link.TraceState),
 		})
 	}
@@ -116,11 +100,11 @@ func convertHitToSpan(hit opensearch.Hit) Span {
 		Kind:                   ptrTo(SpanKind(hit.Source.Kind)),
 		Links:                  ptrTo(links),
 		Name:                   ptrTo(hit.Source.Name),
-		ParentSpanID:           ptrTo(convertIdToBytes(hit.Source.ParentSpanID)),
-		SpanID:                 ptrTo(convertIdToBytes(hit.Source.SpanID)),
+		ParentSpanID:           ptrTo(hit.Source.ParentSpanID),
+		SpanID:                 ptrTo(hit.Source.SpanID),
 		StartTimeUnixNano:      ptrTo(hit.Source.StartTime.UnixNano()),
 		EndTimeUnixNano:        ptrTo(hit.Source.EndTime.UnixNano()),
-		TraceID:                ptrTo(convertIdToBytes(hit.Source.TraceID)),
+		TraceID:                ptrTo(hit.Source.TraceID),
 		TraceState:             ptrTo(hit.Source.TraceState),
 		Status: &Status{
 			Code:    ptrTo(StatusCode(hit.Source.Status.Code)),
@@ -129,15 +113,14 @@ func convertHitToSpan(hit opensearch.Hit) Span {
 	}
 }
 
-func fetchSpanChildren(client *os.Client, datasourceInfo DataSourceInfo, traceID string, spanID string, skip int, take int) ([]Span, error) {
+func fetchSpanChildren(client *os.Client, datasourceInfo DataSourceInfo, traceID string, spanID string) ([]Span, error) {
 	timeField := "@timestamp"
 	if datasourceInfo.TimeField != nil {
 		timeField = *datasourceInfo.TimeField
 	}
 
 	query := fmt.Sprintf(`{
-	"size": %d,
-	"from": %d,
+	"size": 0,
 	"query": {
 		"bool": {
 			"must": [
@@ -147,7 +130,7 @@ func fetchSpanChildren(client *os.Client, datasourceInfo DataSourceInfo, traceID
 		}
 	},
 	"sort": [ { %q: { "order": "asc" } }]
-}`, take, skip, traceID, spanID, timeField)
+}`, traceID, spanID, timeField)
 
 	openSearchResponse, err := opensearch.Search(client, datasourceInfo.Database, query)
 	if err != nil {
@@ -155,7 +138,7 @@ func fetchSpanChildren(client *os.Client, datasourceInfo DataSourceInfo, traceID
 		return nil, err
 	}
 
-	log.Printf("Found %d spans for trace %s and span %s, skipping %d and taking %d", len(openSearchResponse.Hits.Hits), traceID, spanID, skip, take)
+	log.Printf("Found %d spans for trace %s and span %s", len(openSearchResponse.Hits.Hits), traceID, spanID)
 
 	spans := make([]Span, 0, len(openSearchResponse.Hits.Hits))
 	for _, hit := range openSearchResponse.Hits.Hits {
@@ -164,39 +147,11 @@ func fetchSpanChildren(client *os.Client, datasourceInfo DataSourceInfo, traceID
 	return spans, nil
 }
 
-func fetchChildrenWithDepth(client *os.Client, datasourceInfo DataSourceInfo, traceID string, spanID string, skip int, take int, currentDepth int, maxDepth int) ([]Span, error) {
-	if currentDepth > maxDepth {
-		return make([]Span, 0), nil
-	}
-
-	allSpans := make([]Span, 0)
-
-	currentSpans, err := fetchSpanChildren(client, datasourceInfo, traceID, spanID, skip, take)
-	if err != nil {
-		return nil, err
-	}
-
-	for _, span := range currentSpans {
-		// Add the current span to the list of all spans.
-		allSpans = append(allSpans, span)
-
-		// Fetch the children of the current span, recursively.
-		children, err := fetchChildrenWithDepth(client, datasourceInfo, traceID, convertBytesToId(*span.SpanID) /* don't skip any children */, 0, take, currentDepth+1, maxDepth)
-		if err != nil {
-			return nil, err
-		}
-
-		allSpans = append(allSpans, children...)
-	}
-
-	return allSpans, nil
-}
-
-func getInitialTrace(datasourceInfo DataSourceInfo, traceID string, params QueryTraceParams) (TracesData, error) {
+func getInitialTrace(datasourceInfo DataSourceInfo, traceID string) (TraceDetail, error) {
 	client, err := opensearch.GetOpenSearchClient(datasourceInfo.URL)
 	if err != nil {
 		log.Printf("Failed to create OpenSearch client: %v", err)
-		return TracesData{}, err
+		return TraceDetail{}, err
 	}
 
 	query := fmt.Sprintf(`{
@@ -221,7 +176,7 @@ func getInitialTrace(datasourceInfo DataSourceInfo, traceID string, params Query
 	openSearchResponse, err := opensearch.Search(client, datasourceInfo.Database, query)
 	if err != nil {
 		log.Printf("Failed to execute OpenSearch query: %v", err)
-		return TracesData{}, err
+		return TraceDetail{}, err
 	}
 
 	resourceSpans := make([]ResourceSpans, 0, len(openSearchResponse.Hits.Hits))
@@ -234,29 +189,10 @@ func getInitialTrace(datasourceInfo DataSourceInfo, traceID string, params Query
 
 		span := convertHitToSpan(hit)
 
-		take := 10
-		if params.Take != nil {
-			take = *params.Take
-		}
-
-		maxDepth := 5
-		if params.Depth != nil {
-			maxDepth = *params.Depth
-		}
-
-		childSpans, err := fetchChildrenWithDepth(
-			client,
-			datasourceInfo,
-			traceID,
-			hit.Source.SpanID,
-			/* skip */ 0,
-			take,
-			/* currentDepth */ 1,
-			maxDepth,
-		)
+		childSpans, err := fetchSpanChildren(client, datasourceInfo, traceID, hit.Source.SpanID)
 		if err != nil {
 			log.Printf("Failed to fetch span children: %v", err)
-			return TracesData{}, err
+			return TraceDetail{}, err
 		}
 
 		spans := make([]Span, 0, 1+len(childSpans))
@@ -284,41 +220,26 @@ func getInitialTrace(datasourceInfo DataSourceInfo, traceID string, params Query
 		})
 	}
 
-	return TracesData{
+	return TraceDetail{
 		ResourceSpans: &resourceSpans,
 	}, nil
 }
 
-func getSubsequentTrace(datasourceInfo DataSourceInfo, traceID string, spanID string, params QueryTraceParams) (TracesData, error) {
+func getSubsequentTrace(datasourceInfo DataSourceInfo, traceID string, spanID string) (TraceDetail, error) {
 	client, err := opensearch.GetOpenSearchClient(datasourceInfo.URL)
 	if err != nil {
 		log.Printf("Failed to create OpenSearch client: %v", err)
-		return TracesData{}, err
+		return TraceDetail{}, err
 	}
 
-	skip := 0
-	if params.Skip != nil {
-		skip = *params.Skip
-	}
+	log.Printf("Fetching spans for trace %s, span %s", traceID, spanID)
 
-	take := 10
-	if params.Take != nil {
-		take = *params.Take
-	}
-
-	depth := 5
-	if params.Depth != nil {
-		depth = *params.Depth
-	}
-
-	log.Printf("Fetching spans for trace %s, span %s, skipping %d, taking %d, depth %d", traceID, spanID, skip, take, depth)
-
-	spans, err := fetchChildrenWithDepth(client, datasourceInfo, traceID, spanID, skip, take, 1, depth)
+	spans, err := fetchSpanChildren(client, datasourceInfo, traceID, spanID)
 	if err != nil {
-		return TracesData{}, err
+		return TraceDetail{}, err
 	}
 
-	return TracesData{
+	return TraceDetail{
 		ResourceSpans: &([]ResourceSpans{
 			{
 				ScopeSpans: &[]ScopeSpans{
@@ -330,30 +251,30 @@ func getSubsequentTrace(datasourceInfo DataSourceInfo, traceID string, spanID st
 }
 
 func getTraceFromOpenSearch(w http.ResponseWriter, datasourceInfo DataSourceInfo, traceID string, params QueryTraceParams) {
-	var trace TracesData
+	traceResponse := TraceDetailResponse{}
 
 	if params.SpanID == nil {
 		log.Println("Processing initial trace query request for traceId", traceID)
-		t, err := getInitialTrace(datasourceInfo, traceID, params)
+		t, err := getInitialTrace(datasourceInfo, traceID)
 		if err != nil {
 			log.Printf("Failed to get initial trace: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		trace = t
+		traceResponse.Trace = &t
 	} else {
 		log.Println("Processing subsequent trace query request for traceId", traceID, "and spanId", *params.SpanID)
-		t, err := getSubsequentTrace(datasourceInfo, traceID, *params.SpanID, params)
+		t, err := getSubsequentTrace(datasourceInfo, traceID, *params.SpanID)
 		if err != nil {
 			log.Printf("Failed to get subsequent trace: %v", err)
 			http.Error(w, err.Error(), http.StatusInternalServerError)
 			return
 		}
-		trace = t
+		traceResponse.Trace = &t
 	}
 
 	w.Header().Add("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(trace); err != nil {
+	if err := json.NewEncoder(w).Encode(traceResponse); err != nil {
 		log.Printf("Failed to encode response to JSON: %v", err)
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
@@ -362,51 +283,24 @@ func getTraceFromOpenSearch(w http.ResponseWriter, datasourceInfo DataSourceInfo
 }
 
 func proxyTrace(w http.ResponseWriter, datasourceInfo DataSourceInfo, traceID string, params QueryTraceParams) {
-	depth := 5
-	if params.Depth != nil {
-		depth = *params.Depth
-	}
-
-	childrenLimit := 10
-	if params.ChildrenLimit != nil {
-		childrenLimit = *params.ChildrenLimit
-	}
-
 	var url string
 
 	if params.SpanID == nil {
 		url = fmt.Sprintf(
-			"%s/api/v2/traces/%s?start=%d&end=%d&spanId=%s&depth=%d&childrenLimit=%d",
+			"%s/api/v2/traces/%s?start=%d&end=%d",
 			datasourceInfo.URL,
 			traceID,
 			params.Start,
 			params.End,
-			*params.SpanID,
-			depth,
-			childrenLimit,
 		)
 	} else {
-		skip := 0
-		if params.Skip != nil {
-			skip = *params.Skip
-		}
-
-		take := 10
-		if params.Take != nil {
-			take = *params.Take
-		}
-
 		url = fmt.Sprintf(
-			"%s/api/v2/traces/%s?start=%d&end=%d&spanId=%s&depth=%d&childrenLimit=%d&skip=%d&take=%d",
+			"%s/api/v2/traces/%s?start=%d&end=%d&spanId=%s",
 			datasourceInfo.URL,
 			traceID,
 			params.Start,
 			params.End,
 			*params.SpanID,
-			depth,
-			childrenLimit,
-			skip,
-			take,
 		)
 	}
 
@@ -455,6 +349,8 @@ func (siw *ServerInterfaceImpl) QueryTrace(w http.ResponseWriter, req *http.Requ
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
+
+	log.Printf("Raw request: %+v", request)
 
 	if request.Type == "tempo" {
 		// This only works for a custom Tempo api that supports optimized trace queries.

--- a/provisioning/datasources/opensearch.yaml
+++ b/provisioning/datasources/opensearch.yaml
@@ -1,9 +1,5 @@
 apiVersion: 1
 
-deleteDatasources:
-  - name: OpenSearch
-    orgId: 1
-
 datasources:
   - name: OpenSearch
     type: grafana-opensearch-datasource

--- a/provisioning/datasources/tempo.yml
+++ b/provisioning/datasources/tempo.yml
@@ -1,9 +1,5 @@
 apiVersion: 1
 
-deleteDatasources:
-  - name: Tempo
-    orgId: 1
-
 datasources:
   - name: Tempo
     type: tempo

--- a/scripts/create-depth-trace.js
+++ b/scripts/create-depth-trace.js
@@ -11,12 +11,12 @@ const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
 const rndFloat = (min, max) => Math.random() * (max - min) + min;
 
 // ---------- parameters ----------
-const NUM_SERVICES = 2;
-const CHILDREN = 30;
+const NUM_SERVICES = 1;
+const CHILDREN = 3;
 
 // ---------- tracer provider ----------
 const resource = resourceFromAttributes({
-  [ATTR_SERVICE_NAME]: 'my-large-trace-provider',
+  [ATTR_SERVICE_NAME]: `my-large-trace-provider-${new Date().toISOString()}`,
   'other-resource-attribute': 'other-resource-attribute-value',
 });
 

--- a/scripts/query.js
+++ b/scripts/query.js
@@ -2,17 +2,19 @@
 
 const OPENSEARCH_URL = process.env.OPENSEARCH_URL || 'http://localhost:9200';
 const INDEX_PATTERN = process.env.INDEX_PATTERN || 'ss4o_traces-default-namespace';
-const SPAN_ID = process.env.SPAN_ID || 'a994680e93bfdd67';
-const TRACE_ID = process.env.TRACE_ID || '9cc8bb7cbfef17b661c69ca0cf7e9003';
+const SPAN_ID = process.env.SPAN_ID || '15a06c67a9c2de5e';
+const TRACE_ID = process.env.TRACE_ID || '88995d119f2e0efc8fdb04c77293317a';
 
 async function main() {
   const url = `${OPENSEARCH_URL}/${INDEX_PATTERN}/_search`;
-  const query = `{
+
+  // First query: Get the spans that match our criteria
+  const initialQuery = `{
 	"query": {
 		"bool": {
 			"must": [
 				{ "term": { "traceId": "${TRACE_ID}" } },
-				{ "term": { "parentSpanId": "" } }
+				{ "term": { "parentSpanId": "${SPAN_ID}" } }
 			]
 		}
 	},
@@ -20,18 +22,81 @@ async function main() {
 }`;
 
   const res = await fetch(url, {
-    method: 'POST', // GET also works with bodies, but ES docs use POST
+    method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: query,
+    body: initialQuery,
   });
 
   const json = await res.json();
   if (!res.ok) {
-    console.error('Search failed:', JSON.stringify(json, null, 2));
+    console.error('Initial search failed:', JSON.stringify(json, null, 2));
     process.exit(1);
   }
 
+  console.log('Initial query results:');
   console.log(JSON.stringify(json, null, 2));
+
+  // Extract spanIds from the results
+  const spanIds = json.hits.hits.map((hit) => hit._source.spanId);
+
+  if (spanIds.length === 0) {
+    console.log('No spans found in initial query');
+    return;
+  }
+
+  console.log(`\nFound ${spanIds.length} spans, now counting children for each...`);
+
+  // Second query: Count children for each spanId using targeted aggregation
+  const childCountQuery = `{
+	"size": 0,
+	"query": {
+		"bool": {
+			"must": [
+				{ "term": { "traceId": "${TRACE_ID}" } },
+				{ "terms": { "parentSpanId": ${JSON.stringify(spanIds)} } }
+			]
+		}
+	},
+	"aggs": {
+		"child_counts_by_parent": {
+			"terms": {
+				"field": "parentSpanId",
+				"size": ${spanIds.length}
+			}
+		}
+	}
+}`;
+
+  console.log(childCountQuery);
+
+  const childRes = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: childCountQuery,
+  });
+
+  const childJson = await childRes.json();
+  if (!childRes.ok) {
+    console.error('Child count search failed:', JSON.stringify(childJson, null, 2));
+    process.exit(1);
+  }
+
+  console.log('\nChild count results:');
+  console.log(JSON.stringify(childJson, null, 2));
+
+  // Create a summary
+  const childCounts = new Map();
+  if (childJson.aggregations && childJson.aggregations.child_counts_by_parent) {
+    childJson.aggregations.child_counts_by_parent.buckets.forEach((bucket) => {
+      childCounts.set(bucket.key, bucket.doc_count);
+    });
+  }
+
+  console.log('\nSummary:');
+  spanIds.forEach((spanId) => {
+    const childCount = childCounts.get(spanId) || 0;
+    console.log(`Span ${spanId}: ${childCount} children`);
+  });
 }
 
 main().catch((err) => {

--- a/scripts/query.js
+++ b/scripts/query.js
@@ -3,33 +3,26 @@
 const OPENSEARCH_URL = process.env.OPENSEARCH_URL || 'http://localhost:9200';
 const INDEX_PATTERN = process.env.INDEX_PATTERN || 'ss4o_traces-default-namespace';
 const SPAN_ID = process.env.SPAN_ID || 'a994680e93bfdd67';
-const TRACE_ID = process.env.TRACE_ID || 'de1830392ffedd1675754617e9249e93';
+const TRACE_ID = process.env.TRACE_ID || '9cc8bb7cbfef17b661c69ca0cf7e9003';
 
 async function main() {
   const url = `${OPENSEARCH_URL}/${INDEX_PATTERN}/_search`;
-  const query = {
-    query: {
-      bool: {
-        must: [
-          {
-            term: {
-              traceId: TRACE_ID,
-            },
-          },
-          {
-            term: {
-              parentSpanId: '',
-            },
-          },
-        ],
-      },
-    },
-  };
+  const query = `{
+	"query": {
+		"bool": {
+			"must": [
+				{ "term": { "traceId": "${TRACE_ID}" } },
+				{ "term": { "parentSpanId": "" } }
+			]
+		}
+	},
+	"sort": [ { "@timestamp": { "order": "asc" } }]
+}`;
 
   const res = await fetch(url, {
     method: 'POST', // GET also works with bodies, but ES docs use POST
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(query),
+    body: query,
   });
 
   const json = await res.json();

--- a/scripts/tempo.js
+++ b/scripts/tempo.js
@@ -1,11 +1,19 @@
 const q = '{ }';
-const start = Math.floor(Date.now() / 1000) - 3600;
+const start = Math.floor(Date.now() / 1000) - 360000;
 const end = Math.floor(Date.now() / 1000);
 
-const res = await fetch(`http://localhost:3200/api/search?start=${start}&end=${end}&q=${encodeURIComponent(q)}`, {
+const resSearch = await fetch(`http://localhost:3200/api/search?start=${start}&end=${end}&q=${encodeURIComponent(q)}`, {
   method: 'GET', // GET also works with bodies, but ES docs use POST
   headers: { 'Content-Type': 'application/json' },
 });
 
-const json = await res.json();
-console.log(json);
+let json = await resSearch.json();
+console.log(json, { depth: 10 });
+
+const resTrace = await fetch(`http://localhost:3200/api/v2/traces/1cbf18d5d144aa4e7bdd24eed1413c4f`, {
+  method: 'GET', // GET also works with bodies, but ES docs use POST
+  headers: { 'Content-Type': 'application/json' },
+});
+
+json = await resTrace.json();
+console.log(json, { depth: 10 });

--- a/src/components/Span/Span.tsx
+++ b/src/components/Span/Span.tsx
@@ -1,20 +1,26 @@
 import React from 'react';
 import { Icon } from '@grafana/ui';
-import { calculateColourBySpanId } from '../../utils/utils.timeline';
+import { calculateColourBySpanId, mkMilisecondsFromNanoSeconds } from '../../utils/utils.timeline';
 import type { Span as SpanType } from '../../pages/TraceDetail';
 
 type SpanNodeProps = SpanType & {
   index: number;
   loadMore: (index: number, spanId: string, currentLevel: number) => void;
   hasChildren: boolean;
-  traceStartTime: number;
-  traceDuration: number;
+  traceStartTimeInMiliseconds: number;
+  traceDurationInMiliseconds: number;
   onSelect: (span: SpanType) => void;
 };
 
 export const Span = (props: SpanNodeProps) => {
-  const offset = ((props.startTimeUnixNano - props.traceStartTime) / props.traceDuration) * 100;
-  const width = ((props.endTimeUnixNano - props.startTimeUnixNano) / props.traceDuration) * 100;
+  const offset =
+    ((mkMilisecondsFromNanoSeconds(props.startTimeUnixNano) - props.traceStartTimeInMiliseconds) /
+      props.traceDurationInMiliseconds) *
+    100;
+  const width =
+    ((mkMilisecondsFromNanoSeconds(props.endTimeUnixNano) - mkMilisecondsFromNanoSeconds(props.startTimeUnixNano)) /
+      props.traceDurationInMiliseconds) *
+    100;
 
   const canLoadMore = props.hasMore;
 

--- a/src/components/Span/Span.tsx
+++ b/src/components/Span/Span.tsx
@@ -39,7 +39,7 @@ export const Span = (props: SpanNodeProps) => {
               title="Load more traces"
               onClick={(e) => {
                 e.stopPropagation();
-                props.loadMore(props.index, props.spanID, props.level);
+                props.loadMore(props.index, props.spanId, props.level);
               }}
             />
           )}
@@ -47,7 +47,7 @@ export const Span = (props: SpanNodeProps) => {
       </div>
       <div
         className="w-2/3 h-full relative border-l-3"
-        style={{ borderColor: calculateColourBySpanId(props.level > 2 ? props.parentSpanId || '' : props.spanID) }} // Limitation in tailwind dynamic class construction: Check README.md for more details
+        style={{ borderColor: calculateColourBySpanId(props.level > 2 ? props.parentSpanId || '' : props.spanId) }} // Limitation in tailwind dynamic class construction: Check README.md for more details
       >
         <div className="h-full relative mx-4">
           <div

--- a/src/components/Span/SpanDetailsPanel.tsx
+++ b/src/components/Span/SpanDetailsPanel.tsx
@@ -15,7 +15,7 @@ export const SpanDetailPanel = ({ span, onClose }: { span: SpanType; onClose: ()
           <strong>Name:</strong> <pre>{span.name}</pre>
         </div>
         <div>
-          <strong>ID:</strong> <pre>{span.spanID}</pre>
+          <strong>ID:</strong> <pre>{span.spanId}</pre>
         </div>
         <div>
           <strong>Trace ID:</strong>

--- a/src/pages/TraceDetail.tsx
+++ b/src/pages/TraceDetail.tsx
@@ -9,7 +9,7 @@ import { ApiPaths, type components } from '../schema.gen';
 import type { datasource } from './TraceOverview';
 import { BASE_URL } from '../constants';
 import { Span as SpanComponent, SpanDetailPanel } from '../components/Span';
-import { mkMilisecondsFromNano, mkMilisecondsFromNanoSeconds } from 'utils/utils.timeline';
+import { mkMilisecondsFromNanoSeconds } from 'utils/utils.timeline';
 
 type TraceResponse = components['schemas']['TraceDetailResponse'];
 type DataSourceInfo = components['schemas']['DataSourceInfo'];

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -178,56 +178,58 @@ function TraceOverview() {
             </div>
 
             {/* Filters */}
-            <div className="mb-6">
-              <div className="flex items-center justify-between mb-4">
-                <h3 className="text-lg font-medium">Filters</h3>
-                {hasActiveFilters && (
-                  <Button variant="secondary" size="sm" onClick={handleClearFilters} icon="times">
-                    Clear Filters
-                  </Button>
-                )}
-              </div>
-
-              <Stack direction="column">
-                {/* Time Range Filter */}
-                <Field label="Time Range" className="self-start">
-                  <TimeRangeInput value={getTimeRangeValue()} onChange={handleTimeRangeChange} showIcon />
-                </Field>
-
-                {/* Query Editor - dynamically loaded */}
-                {selectedDatasource &&
-                  selectedDatasource.type === 'tempo' &&
-                  selectedDatasource.components?.QueryEditor && (
-                    <Field label="Query" className="query-editor">
-                      {(() => {
-                        try {
-                          const QueryEditor = selectedDatasource.components.QueryEditor;
-                          return (
-                            <QueryEditor
-                              datasource={selectedDatasource}
-                              query={query}
-                              onChange={(newQuery: DataQuery) => {
-                                setQuery(newQuery);
-                                const tempoQuery = newQuery as TempoQuery;
-                                if (tempoQuery.query) {
-                                  updateTraceQL(tempoQuery.query);
-                                }
-                                console.log('Query changed:', newQuery);
-                              }}
-                              onRunQuery={() => {
-                                console.log('Run query requested');
-                              }}
-                            />
-                          );
-                        } catch (error) {
-                          console.error('Failed to render QueryEditor:', error);
-                          return <div>Unable to load query editor</div>;
-                        }
-                      })()}
-                    </Field>
+            {filters.datasource !== undefined && (
+              <div className="mb-6">
+                <div className="flex items-center justify-between mb-4">
+                  <h3 className="text-lg font-medium">Filters</h3>
+                  {hasActiveFilters && (
+                    <Button variant="secondary" size="sm" onClick={handleClearFilters} icon="times">
+                      Clear Filters
+                    </Button>
                   )}
-              </Stack>
-            </div>
+                </div>
+
+                <Stack direction="column">
+                  {/* Time Range Filter */}
+                  <Field label="Time Range" className="self-start">
+                    <TimeRangeInput value={getTimeRangeValue()} onChange={handleTimeRangeChange} showIcon />
+                  </Field>
+
+                  {/* Query Editor - dynamically loaded */}
+                  {selectedDatasource &&
+                    selectedDatasource.type === 'tempo' &&
+                    selectedDatasource.components?.QueryEditor && (
+                      <Field label="Query" className="query-editor">
+                        {(() => {
+                          try {
+                            const QueryEditor = selectedDatasource.components.QueryEditor;
+                            return (
+                              <QueryEditor
+                                datasource={selectedDatasource}
+                                query={query}
+                                onChange={(newQuery: DataQuery) => {
+                                  setQuery(newQuery);
+                                  const tempoQuery = newQuery as TempoQuery;
+                                  if (tempoQuery.query) {
+                                    updateTraceQL(tempoQuery.query);
+                                  }
+                                  console.log('Query changed:', newQuery);
+                                }}
+                                onRunQuery={() => {
+                                  console.log('Run query requested');
+                                }}
+                              />
+                            );
+                          } catch (error) {
+                            console.error('Failed to render QueryEditor:', error);
+                            return <div>Unable to load query editor</div>;
+                          }
+                        })()}
+                      </Field>
+                    )}
+                </Stack>
+              </div>
+            )}
           </Stack>
           {/* Results */}
           {result.isLoading && (
@@ -244,7 +246,7 @@ function TraceOverview() {
             </div>
           )}
 
-          {result.isSuccess && (
+          {result.isSuccess && filters.datasource !== undefined && (
             <div>
               <div className="flex items-center justify-between mb-4">
                 <h3 className="text-lg font-medium">Traces</h3>

--- a/src/pages/TraceOverview.tsx
+++ b/src/pages/TraceOverview.tsx
@@ -8,6 +8,7 @@ import { PluginPage, getBackendSrv, getDataSourceSrv } from '@grafana/runtime';
 import { Combobox, Field, Stack, Button, Icon, TimeRangeInput } from '@grafana/ui';
 import { DataSourceApi, DataSourceJsonData, dateTime, TimeRange } from '@grafana/data';
 import { DataQuery } from '@grafana/schema';
+import { TempoQuery } from '@grafana/schema/dist/esm/raw/composable/tempo/dataquery/x/TempoDataQuery_types.gen';
 import { Link } from 'react-router-dom';
 import { useQuery, useQueryClient, useSuspenseQuery } from '@tanstack/react-query';
 import { type components, ApiPaths } from '../schema.gen';
@@ -207,8 +208,7 @@ function TraceOverview() {
                               query={query}
                               onChange={(newQuery: DataQuery) => {
                                 setQuery(newQuery);
-                                // query is a TempoQuery, but I'm not sure where that type should come from.
-                                const tempoQuery = newQuery as any;
+                                const tempoQuery = newQuery as TempoQuery;
                                 if (tempoQuery.query) {
                                   updateTraceQL(tempoQuery.query);
                                 }

--- a/src/schema.gen.ts
+++ b/src/schema.gen.ts
@@ -96,8 +96,8 @@ export interface components {
       readonly values?: components['schemas']['KeyValue'][] | null;
     };
     Link: {
-      traceId?: number[] | null;
-      spanId?: number[] | null;
+      traceId?: string;
+      spanId?: string;
       traceState?: string | null;
       readonly attributes?: components['schemas']['KeyValue'][] | null;
       /** Format: int32 */
@@ -122,10 +122,10 @@ export interface components {
       schemaUrl?: string | null;
     };
     Span: {
-      traceId?: number[] | null;
-      spanID?: number[] | null;
+      traceId?: string;
+      spanId?: string;
       traceState?: string | null;
-      parentSpanId?: number[] | null;
+      parentSpanId?: string | null;
       /** Format: int32 */
       flags?: number;
       name?: string | null;
@@ -184,7 +184,6 @@ export interface components {
       startTime?: string;
       /** Format: date-span */
       duration?: string;
-      spanSets?: components['schemas']['SpanSet'][] | null;
     };
     TempoV1Response: {
       metrics?: components['schemas']['TempoMetrics'];
@@ -198,8 +197,11 @@ export interface components {
       scopes?: components['schemas']['TempoScope'][] | null;
       tagValues?: components['schemas']['TagValue'][] | null;
     };
-    TracesData: {
-      readonly resourceSpans?: components['schemas']['ResourceSpans'][] | null;
+    TraceDetail: {
+      readonly resourceSpans?: components['schemas']['ResourceSpans'][];
+    };
+    TraceDetailResponse: {
+      trace?: components['schemas']['TraceDetail'];
     };
     /** @enum {string} */
     ValueOneofCase:
@@ -254,25 +256,10 @@ export interface operations {
       query?: {
         start?: number;
         end?: number;
-        /** @description The depth of the query.
-         *     If not provided, the default depth will be used.
-         *      */
-        depth?: number;
-        /** @description The maximum number of children to fetch on each level.
-         *      */
-        childrenLimit?: number;
         /** @description The parent span id to start the query from.
          *     If not provided, the root span will be used.
          *      */
         spanId?: string;
-        /** @description The number of spans to skip.
-         *     Should only be used in combination with spanId.
-         *      */
-        skip?: number;
-        /** @description The number of spans to take.
-         *     Should only be used in combination with spanId.
-         *      */
-        take?: number;
       };
       header?: never;
       path: {
@@ -292,7 +279,7 @@ export interface operations {
           [name: string]: unknown;
         };
         content: {
-          'application/json': components['schemas']['TracesData'];
+          'application/json': components['schemas']['TraceDetailResponse'];
         };
       };
     };

--- a/src/utils/utils.timeline.ts
+++ b/src/utils/utils.timeline.ts
@@ -18,3 +18,7 @@ export const calculateColourBySpanId = (spanId: string) => {
   }, 0);
   return `hsl(${hash % 360}, 100%, 50%)`;
 };
+
+export function mkMilisecondsFromNanoSeconds(nanoSeconds: number) {
+  return nanoSeconds / 1000000;
+}


### PR DESCRIPTION
Our current Go code is loading different depths of child spans.
This might be a bit too complex to start with.
The new requirement is to start with a simple "Load children" of span action.
Thus, not needing the depth and paging, just grab all the children.

In this PR, I'm also trying to proxy the Trace detail call to the original Tempo API.
There, the UI should work, but just load all the data immediately.