### PR TITLE
Add depth query parameter

### DIFF
--- a/api.yml
+++ b/api.yml
@@ -60,17 +60,19 @@ paths:
           schema:
             type: integer # unix epoch seconds
           in: query
-        # - name: depth # TODO: to -1 all, 0 none, 1 next level.
-        #   description: |
-        #     The depth of the query.
-        #     If not provided, the default depth will be used.
-        #   schema:
-        #     type: integer
-        #   in: query
+        - name: depth
+          description: |
+            The depth of the query.
+            If not provided, the entire trace will be returned.
+            Should be a positive integer.
+          schema:
+            type: integer
+          in: query
         - name: spanId
           description: |
             The parent span id to start the query from.
             If not provided, the root span will be used.
+            Requires depth to be present.
           schema:
             type: string
           in: query

--- a/pkg/plugin/api.gen.go
+++ b/pkg/plugin/api.gen.go
@@ -217,6 +217,11 @@ type QueryTraceParams struct {
 	Start *int `form:"start,omitempty" json:"start,omitempty"`
 	End   *int `form:"end,omitempty" json:"end,omitempty"`
 
+	// Depth The depth of the query.
+	// If not provided, the entire trace will be returned.
+	// Should be a positive integer.
+	Depth *int `form:"depth,omitempty" json:"depth,omitempty"`
+
 	// SpanID The parent span id to start the query from.
 	// If not provided, the root span will be used.
 	SpanID *string `form:"spanId,omitempty" json:"spanId,omitempty"`
@@ -349,6 +354,14 @@ func (siw *ServerInterfaceWrapper) QueryTrace(w http.ResponseWriter, r *http.Req
 	err = runtime.BindQueryParameter("form", true, false, "end", r.URL.Query(), &params.End)
 	if err != nil {
 		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "end", Err: err})
+		return
+	}
+
+	// ------------- Optional query parameter "depth" -------------
+
+	err = runtime.BindQueryParameter("form", true, false, "depth", r.URL.Query(), &params.Depth)
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "depth", Err: err})
 		return
 	}
 

--- a/src/pages/TraceDetail.tsx
+++ b/src/pages/TraceDetail.tsx
@@ -115,7 +115,7 @@ function TraceDetail() {
         }
 
         const responses = getBackendSrv().fetch<TraceResponse>({
-          url: `${BASE_URL}${ApiPaths.queryTrace.replace('{traceId}', traceId)}`,
+          url: `${BASE_URL}${ApiPaths.queryTrace.replace('{traceId}', traceId)}?depth=1`,
           method: 'POST',
           data: {
             type: datasource.type,
@@ -180,7 +180,7 @@ function TraceDetail() {
       }
 
       const responses = getBackendSrv().fetch<TraceResponse>({
-        url: `${BASE_URL}${ApiPaths.queryTrace.replace('{traceId}', traceId)}?spanId=${spanId}`,
+        url: `${BASE_URL}${ApiPaths.queryTrace.replace('{traceId}', traceId)}?spanId=${spanId}&depth=1`,
         method: 'POST',
         data: {
           type: datasource.type,

--- a/src/schema.gen.ts
+++ b/src/schema.gen.ts
@@ -256,6 +256,11 @@ export interface operations {
       query?: {
         start?: number;
         end?: number;
+        /** @description The depth of the query.
+         *     If not provided, the entire trace will be returned.
+         *     Should be a positive integer.
+         *      */
+        depth?: number;
         /** @description The parent span id to start the query from.
          *     If not provided, the root span will be used.
          *      */


### PR DESCRIPTION
If the API supports `?depth`, which our extensions to the API will, we will have lazy loading.
Otherwise, Tempo API will return the entire trace.