### PR TITLE
Target Grafana v11

### DIFF
--- a/.config/Dockerfile
+++ b/.config/Dockerfile
@@ -1,4 +1,4 @@
-ARG grafana_version=latest
+ARG grafana_version=11.6.3-security-01-ubuntu
 ARG grafana_image=grafana-enterprise
 
 FROM grafana/${grafana_image}:${grafana_version}

--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       args:
         grafana_image: ${GRAFANA_IMAGE:-grafana-enterprise}
-        grafana_version: ${GRAFANA_VERSION:-12.0.1}
+        grafana_version: ${GRAFANA_VERSION:-11.6.3-security-01-ubuntu}
         development: ${DEVELOPMENT:-false}
         anonymous_auth_enabled: ${ANONYMOUS_AUTH_ENABLED:-true}
     ports:


### PR DESCRIPTION
We also want to support v11.
Our plugin works for both, so we should simply update our Docker image to version 11.