### PR TITLE
Use mouseDown event to load child spans

### DIFF
--- a/src/components/Span/Span.tsx
+++ b/src/components/Span/Span.tsx
@@ -46,7 +46,7 @@ export const Span = (props: SpanNodeProps) => {
               name="plus"
               className="text-xs cursor-pointer"
               title="Load more traces"
-              onClick={(e) => {
+              onMouseDown={(e) => {
                 e.stopPropagation();
                 props.loadMore(props.index, props);
               }}


### PR DESCRIPTION
This is a little trick to make things "feel" a bit faster.
The moment the user clicks there is no need to wait for the mouseup to happen for us to load the data.