### PR TITLE
Adjusted naming to match Jaeger UI

### DIFF
--- a/scripts/create-depth-trace.js
+++ b/scripts/create-depth-trace.js
@@ -57,17 +57,20 @@ async function main() {
   const rootTracer = rootProvider.getTracer('root');
   const rootSpan = rootTracer.startSpan('root');
   rootSpan.setAttribute('root-span-attribute-xyz', 123);
+  rootSpan.setAttribute('k8s.container.name', 'root-container');
   const rootCtx = trace.setSpan(otContext.active(), rootSpan);
 
   for (let i = 0; i < NUM_SERVICES; i++) {
     // Use the service tracer to create service spans with proper namespace
     const serviceSpan = tracers[i].startSpan(`service_${i + 1}`, undefined, rootCtx);
+    serviceSpan.setAttribute('k8s.container.name', `service-container-${i + 1}`);
     const serviceCtx = trace.setSpan(rootCtx, serviceSpan);
 
     for (let j = 0; j < CHILDREN; j++) {
       // Use the same service tracer for child spans to maintain namespace
       const childSpan = tracers[i].startSpan(`service_${i + 1}_child_${j + 1}`, undefined, serviceCtx);
       childSpan.setAttribute('child-span-attribute-xyz', 456);
+      childSpan.setAttribute('k8s.container.name', `container-${i + 1}-${j + 1}`);
       await sleep(rndFloat(10, 50));
       childSpan.setAttribute('foo', 'bar');
       childSpan.setAttribute('yozora', crypto.randomUUID());

--- a/scripts/create-large-trace.js
+++ b/scripts/create-large-trace.js
@@ -61,6 +61,7 @@ async function buildTree(parentCtx, currentDepth, maxDepth, spanBudget) {
   const tracer = nextTracer();
   const span = tracer.startSpan(`span-depth-${currentDepth}`, undefined, parentCtx);
   span.setAttribute('depth', currentDepth);
+  span.setAttribute('k8s.container.name', `container-depth-${currentDepth}`);
 
   const ctxWithSpan = trace.setSpan(parentCtx, span);
 
@@ -71,6 +72,7 @@ async function buildTree(parentCtx, currentDepth, maxDepth, spanBudget) {
       const child = tracer.startSpan(`span-depth-${currentDepth + 1}_${count}`, undefined, ctxWithSpan);
 
       child.setAttribute('depth', currentDepth + 1);
+      child.setAttribute('k8s.container.name', `container-depth-${currentDepth + 1}-${count}`);
       child.setAttribute('user_id', `user-${count}`);
       child.setAttribute('order_id', `order-${count}`);
       child.setAttribute('region', ['us-east', 'eu-west', 'ap-south', 'sa-east'][count % 4]);

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -132,6 +132,8 @@ async function extractSpans(
     const serviceNamespace =
       span.attributes?.find((a) => a.key === 'service.namespace')?.value?.stringValue || undefined;
 
+    const serviceName = span.attributes?.find((a) => a.key === 'k8s.container.name')?.value?.stringValue || undefined;
+
     spans.push({
       spanId: span.spanID,
       parentSpanId: parentSpanId,
@@ -139,7 +141,7 @@ async function extractSpans(
       level: idToLevelMap.get(span.spanID) || 0,
       startTimeUnixNano: startTimeUnixNano,
       endTimeUnixNano: endTimeUnixNano,
-      name: span.name || '',
+      name: serviceName || span.name || '',
       hasMore: hasMore,
       serviceNamespace,
     });

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -157,7 +157,9 @@ async function loadMoreSpans(
 ): Promise<SpanInfo[]> {
   const q = `{ trace:id = "${traceId}" && span:parentID = "${
     span.spanId
-  }" } | select (span:parentID, span:name, resource.service.namespace${supportsChildCount ? ', childCount' : ''})`;
+  }" } | select (span:parentID, span:name, span.k8s.container.name, resource.service.namespace${
+    supportsChildCount ? ', childCount' : ''
+  })`;
   const start = mkUnixEpochFromNanoSeconds(span.startTimeUnixNano);
   // As a precaution, we add 1 second to the end time.
   // This is to avoid any rounding errors where the microseconds or nanoseconds are not included in the end time.
@@ -194,7 +196,7 @@ function TraceDetail({
       queryFn: async () => {
         const start = mkUnixEpochFromMiliseconds(startTimeInMs);
         const end = start + 1;
-        const q = `{ trace:id = "${traceId}" && nestedSetParent = -1 } | select (span:name, resource.service.namespace${
+        const q = `{ trace:id = "${traceId}" && nestedSetParent = -1 } | select (span:name, span.k8s.container.name, resource.service.namespace${
           supportsChildCount ? ', childCount' : ''
         })`;
         const data = await search(datasourceUid, q, start, end);


### PR DESCRIPTION
Displays the container name in the span details.
This change makes it easier to identify the source of spans matching the naming we see in the Jaeger UI.
Extended scripts to populate attribs with correct values, but kept fallback values just in case attribs are missing