### PR TITLE
Improves Span Overlay and Trace Detail Layout

### DIFF
--- a/src/components/Span/Accordion.tsx
+++ b/src/components/Span/Accordion.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import clsx from 'clsx';
+
+export const Accordion = ({
+  title,
+  isExpanded,
+  onToggle,
+  children,
+}: {
+  title: string;
+  isExpanded: boolean;
+  onToggle: () => void;
+  children: React.ReactNode;
+}) => (
+  <div className="border-t border-gray-600 pt-4">
+    <button
+      onClick={onToggle}
+      className="w-full flex items-center justify-between text-sm font-semibold text-gray-300 hover:text-gray-100 transition-colors duration-200 mb-2"
+    >
+      <span>{title}</span>
+      <svg
+        className={clsx('w-4 h-4 transition-transform duration-200', isExpanded ? 'rotate-180' : 'rotate-0')}
+        fill="none"
+        stroke="currentColor"
+        viewBox="0 0 24 24"
+      >
+        <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+      </svg>
+    </button>
+
+    <div
+      className={clsx(
+        'overflow-hidden transition-all duration-300 ease-in-out',
+        isExpanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+      )}
+    >
+      {children}
+    </div>
+  </div>
+);
+
+export default Accordion;

--- a/src/components/Span/Accordion.tsx
+++ b/src/components/Span/Accordion.tsx
@@ -12,7 +12,7 @@ export const Accordion = ({
   onToggle: () => void;
   children: React.ReactNode;
 }) => (
-  <div className="border-t border-gray-600 pt-4">
+  <div className="border-t border-gray-600 pt-4 mt-2">
     <button
       onClick={onToggle}
       className="w-full flex items-center justify-between text-sm font-semibold text-gray-300 hover:text-gray-100 transition-colors duration-200 mb-2"

--- a/src/components/Span/SpanDetailsPanel.tsx
+++ b/src/components/Span/SpanDetailsPanel.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 import clsx from 'clsx';
 
 import type { SpanInfo } from '../../types';
@@ -64,6 +64,19 @@ export const SpanDetailPanel = ({
   onClose: () => void;
   datasourceUid: string;
 }) => {
+  const [expandedSections, setExpandedSections] = useState({
+    additionalData: false,
+    events: false,
+    process: false,
+  });
+
+  const toggleSection = (section: keyof typeof expandedSections) => {
+    setExpandedSections((prev) => ({
+      ...prev,
+      [section]: !prev[section],
+    }));
+  };
+
   const result = useQuery<Record<string, any>>({
     queryKey: ['trace', span.traceId, 'span', span.spanId, 'details'],
     queryFn: async () => {
@@ -99,38 +112,100 @@ export const SpanDetailPanel = ({
     { key: 'Duration', value: { stringValue: formatDuration(span.endTimeUnixNano - span.startTimeUnixNano) } },
   ];
 
+  // Dummy data for Events section
+  const eventsData: KeyValue[] = [
+    { key: 'Event Count', value: { intValue: 3 } },
+    { key: 'Event Type', value: { stringValue: 'log' } },
+    { key: 'Event Name', value: { stringValue: 'user.login' } },
+    { key: 'Event Timestamp', value: { stringValue: formatUnixNanoToDateTime(span.startTimeUnixNano + 1000000) } },
+    { key: 'Event Attributes', value: { stringValue: '{"user_id": "12345", "ip": "192.168.1.1"}' } },
+  ];
+
+  // Dummy data for Process section
+  const processData: KeyValue[] = [
+    { key: 'Process ID', value: { intValue: 1234 } },
+    { key: 'Process Name', value: { stringValue: 'web-server' } },
+    { key: 'Service Name', value: { stringValue: 'auth-service' } },
+    { key: 'Service Version', value: { stringValue: '1.2.3' } },
+    { key: 'Host Name', value: { stringValue: 'server-01' } },
+    { key: 'Environment', value: { stringValue: 'production' } },
+  ];
+
   const rowClassName = (index: number) => {
     return clsx('leading-7', index % 2 === 0 ? 'bg-gray-800' : 'bg-gray-700');
   };
 
   const flattenedAttributes = result.isSuccess ? result.data : {};
 
+  const AccordionSection = ({
+    title,
+    isExpanded,
+    onToggle,
+    children,
+  }: {
+    title: string;
+    isExpanded: boolean;
+    onToggle: () => void;
+    children: React.ReactNode;
+  }) => (
+    <div className="border-t border-gray-600 pt-4">
+      <button
+        onClick={onToggle}
+        className="w-full flex items-center justify-between text-sm font-semibold text-gray-300 hover:text-gray-100 transition-colors duration-200 mb-2"
+      >
+        <span>{title}</span>
+        <svg
+          className={clsx('w-4 h-4 transition-transform duration-200', isExpanded ? 'rotate-180' : 'rotate-0')}
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+        >
+          <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M19 9l-7 7-7-7" />
+        </svg>
+      </button>
+
+      <div
+        className={clsx(
+          'overflow-hidden transition-all duration-300 ease-in-out',
+          isExpanded ? 'max-h-96 opacity-100' : 'max-h-0 opacity-0'
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+
   return (
     <div className="z-10">
       <div className="overflow-hidden text-sm">
-        <table className="w-full">
-          <tbody>
-            {basicSpanData.map((item, index) => (
-              <tr key={item.key} className={rowClassName(index)}>
-                <td className="font-semibold text-gray-300 border-r border-gray-600 w-1/3 mx-4">
-                  <span className="px-2 py-2">{item.key}</span>{' '}
-                  {/* TODO: padding & margins are overriden to 0 by the global CSS and it is not possible to set it on the td tag */}
-                </td>
-                <td>{item.value && formatValue(item.value)}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        {/* Basic Span Data Section */}
+        <div className="mb-4">
+          <div className="text-sm font-semibold text-gray-300 mb-2">Span Details</div>
+          <table className="w-full">
+            <tbody>
+              {basicSpanData.map((item, index) => (
+                <tr key={item.key} className={rowClassName(index)}>
+                  <td className="font-semibold text-gray-300 border-r border-gray-600 w-1/3 mx-4">
+                    <span className="px-2 py-2">{item.key}</span>
+                  </td>
+                  <td>{item.value && formatValue(item.value)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Additional Span Data Section */}
         {Object.keys(flattenedAttributes).length > 0 && (
-          <>
-            <div className="mt-4 mb-2 text-sm font-semibold text-gray-300">Additional Span Data</div>
+          <AccordionSection
+            title="Additional Span Data"
+            isExpanded={expandedSections.additionalData}
+            onToggle={() => toggleSection('additionalData')}
+          >
             <table className="w-full">
               <tbody>
                 {Object.entries(flattenedAttributes).map(([key, value], index) => (
-                  <tr
-                    key={key}
-                    className={rowClassName(basicSpanData.length + Object.keys(flattenedAttributes).length + index)}
-                  >
+                  <tr key={key} className={rowClassName(index)}>
                     <td className="font-semibold text-gray-300 border-r border-gray-600 w-1/3">
                       <span className="px-2 py-2">{key}</span>
                     </td>
@@ -139,8 +214,44 @@ export const SpanDetailPanel = ({
                 ))}
               </tbody>
             </table>
-          </>
+          </AccordionSection>
         )}
+
+        {/* Events Section */}
+        <AccordionSection title="Events" isExpanded={expandedSections.events} onToggle={() => toggleSection('events')}>
+          <table className="w-full">
+            <tbody>
+              {eventsData.map((item, index) => (
+                <tr key={item.key} className={rowClassName(index)}>
+                  <td className="font-semibold text-gray-300 border-r border-gray-600 w-1/3">
+                    <span className="px-2 py-2">{item.key}</span>
+                  </td>
+                  <td>{item.value && formatValue(item.value)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </AccordionSection>
+
+        {/* Process Section */}
+        <AccordionSection
+          title="Process"
+          isExpanded={expandedSections.process}
+          onToggle={() => toggleSection('process')}
+        >
+          <table className="w-full">
+            <tbody>
+              {processData.map((item, index) => (
+                <tr key={item.key} className={rowClassName(index)}>
+                  <td className="font-semibold text-gray-300 border-r border-gray-600 w-1/3">
+                    <span className="px-2 py-2">{item.key}</span>
+                  </td>
+                  <td>{item.value && formatValue(item.value)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </AccordionSection>
       </div>
     </div>
   );

--- a/src/components/Span/SpanDetailsPanel.tsx
+++ b/src/components/Span/SpanDetailsPanel.tsx
@@ -30,25 +30,27 @@ async function getTagAttributes(
 
   // Add span tags to the groups
   for (const tag of spanTags) {
-    if (currentLength + tag.length < maxLength) {
-      currentGroup.push(tag);
-      currentLength += tag.length;
+    const tagIdentifier = `span.${tag}`;
+    if (currentLength + tagIdentifier.length < maxLength) {
+      currentGroup.push(tagIdentifier);
+      currentLength += tagIdentifier.length;
     } else {
       groups.push(currentGroup);
-      currentGroup = [tag];
-      currentLength = tag.length;
+      currentGroup = [tagIdentifier];
+      currentLength = tagIdentifier.length;
     }
   }
 
   // Add resource tags to the groups
   for (const tag of resourceTags) {
-    if (currentLength + tag.length < maxLength) {
-      currentGroup.push(tag);
-      currentLength += tag.length;
+    const tagIdentifier = `resource.${tag}`;
+    if (currentLength + tagIdentifier.length < maxLength) {
+      currentGroup.push(tagIdentifier);
+      currentLength += tagIdentifier.length;
     } else {
       groups.push(currentGroup);
-      currentGroup = [tag];
-      currentLength = tag.length;
+      currentGroup = [tagIdentifier];
+      currentLength = tagIdentifier.length;
     }
   }
 
@@ -57,9 +59,7 @@ async function getTagAttributes(
   }
 
   const promises = groups.map(async (group) => {
-    const q = `{ trace:id = "${traceId}" && span:id = "${spanId}" } | select (${group
-      .map((t) => `span.${t}`)
-      .join(', ')})`;
+    const q = `{ trace:id = "${traceId}" && span:id = "${spanId}" } | select (${group.join(', ')})`;
     const data = await search(datasourceUid, q, start, end, 1);
     return data.traces?.[0].spanSets?.[0].spans?.[0].attributes || [];
   });

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -39,8 +39,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         }}
       >
         {/* Header */}
-        <div className="flex items-center justify-between p-2 border-b border-gray-700 bg-gray-900">
-          <h3 className="text-lg font-semibold text-white">{title}</h3>
+        <div className="absolute top-0 right-0">
           <button
             onClick={onClose}
             className="p-1 rounded hover:bg-gray-700 transition-colors"

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -343,8 +343,10 @@ function TraceDetail({
   }
 
   return (
-    <div className="flex relative">
-      <div className="flex-grow flex flex-col">
+    // Grafana sets padding on the parent panel which causes our content to overflow.
+    // This negative margin compensates for that padding to keep content within bounds.
+    <div className="flex relative m-[-8px]">
+      <div className="flex-grow flex flex-col px-2">
         <div className="flex">
           <TraceViewerHeader
             traceId={traceId}


### PR DESCRIPTION
Improves the layout and styling of the span overlay drawer and trace detail view.

- Moves the close button in the span overlay drawer to the top right for better visibility.
- Adds negative margins to the TraceDetail component to compensate for Grafana's panel padding, preventing content overflow.

<img width="1262" height="620" alt="image" src="https://github.com/user-attachments/assets/5542ad95-9061-4448-a9f6-d8276b89ef5e" />
