### PR TITLE
Improves span overlay drawer resizing

### DIFF
--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -16,13 +16,63 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
   title = 'Span Details',
   panelWidth,
 }) => {
+  // Default width: up to 50% of panel width, but no more than 378px
+  const defaultWidthPx = Math.min(panelWidth * 0.5, 378);
+  const [widthPercent, setWidthPercent] = React.useState<number>((defaultWidthPx / panelWidth) * 100);
+  const isResizingRef = React.useRef<boolean>(false);
+  const drawerRef = React.useRef<HTMLDivElement | null>(null);
+
+  const onMouseDownResize = React.useCallback((e: React.MouseEvent<HTMLDivElement>) => {
+    isResizingRef.current = true;
+    e.preventDefault();
+    e.stopPropagation();
+  }, []);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const controller = new AbortController();
+    // Resize by dragging the left edge of the drawer
+    window.addEventListener(
+      'mousemove',
+      (e: MouseEvent) => {
+        if (!isResizingRef.current) {
+          return;
+        }
+        const drawer = drawerRef.current;
+        const container = drawer?.parentElement as HTMLElement | null; // absolute container from TraceDetail
+        if (!container) {
+          return;
+        }
+        const bounds = container.getBoundingClientRect();
+        // Desired width is distance from mouse to the right edge of the container
+        const widthPx = Math.max(0, bounds.right - e.clientX);
+        const minPx = 220; // minimum comfortable width
+        const maxPx = Math.min(bounds.width * 0.7, Math.max(378, bounds.width * 0.3));
+        const clamped = Math.min(Math.max(widthPx, minPx), maxPx);
+        const percent = (clamped / bounds.width) * 100;
+        setWidthPercent(percent);
+      },
+      { signal: controller.signal }
+    );
+    window.addEventListener(
+      'mouseup',
+      () => {
+        if (isResizingRef.current) {
+          isResizingRef.current = false;
+        }
+      },
+      { signal: controller.signal }
+    );
+    return () => controller.abort();
+  }, [isOpen]);
+
+  const drawerWidth = `${(widthPercent / 100) * panelWidth}px`;
+
   if (!isOpen) {
     return null;
   }
-
-  // Calculate drawer width: up to 50% of panel width, but no more than 378px
-  const maxWidth = Math.min(panelWidth * 0.5, 378);
-  const drawerWidth = `${maxWidth}px`;
 
   return (
     <>
@@ -31,6 +81,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
 
       {/* Drawer */}
       <div
+        ref={drawerRef}
         className="absolute top-0 right-0 h-full bg-gray-800 border-l border-gray-700 shadow-lg overflow-hidden z-[1000]"
         style={{
           width: drawerWidth,
@@ -38,6 +89,18 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
           transition: 'transform 0.3s ease-in-out',
         }}
       >
+        {/* Resize handle on the left edge */}
+        <div
+          onMouseDown={onMouseDownResize}
+          title="Drag to resize"
+          className="absolute top-0 left-0 h-full w-[6px] cursor-col-resize hover:bg-gray-600/50 active:bg-gray-500/60 z-[1001]"
+        >
+          <div className="absolute top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2 flex flex-col items-center gap-[2px] pointer-events-none">
+            <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+            <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+            <span className="block w-1 h-1 rounded-full bg-gray-400"></span>
+          </div>
+        </div>
         {/* Header */}
         <div className="absolute top-0 right-0">
           <button
@@ -50,7 +113,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         </div>
 
         {/* Content */}
-        <div className="h-full overflow-y-auto p-1">{children}</div>
+        <div className="h-full overflow-y-auto pl-2 pr-1 py-1">{children}</div>
       </div>
     </>
   );

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -137,7 +137,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         </div>
 
         {/* Content */}
-        <div className="h-full overflow-y-auto pl-2 pr-1 py-1">{children}</div>
+        <div className="h-full overflow-y-auto pl-3 pr-1 py-1">{children}</div>
       </div>
     </>
   );

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -54,11 +54,13 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         const widthPx = Math.max(0, bounds.right - e.clientX);
         const minPx = 220; // minimum comfortable width
         const percentRaw = (widthPx / bounds.width) * 100;
-        // Respect overall layout constraint: left + drawer <= 80%
-        const maxPercent = Math.max(0, 80 - leftColumnPercent);
+        // Respect overall layout constraint: left + drawer <= 90%
+        const maxPercent = Math.max(0, 90 - leftColumnPercent);
+        // Enforce 50% panel width limit
+        const maxPercentWithLimit = Math.min(maxPercent, 50);
         // Convert minPx to percent for clamping
         const minPercent = (minPx / bounds.width) * 100;
-        const percent = Math.min(maxPercent, Math.max(minPercent, percentRaw));
+        const percent = Math.min(maxPercentWithLimit, Math.max(minPercent, percentRaw));
         setWidthPercent(percent);
       },
       { signal: controller.signal }
@@ -85,13 +87,14 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
     onWidthPercentChange?.(widthPercent);
   }, [widthPercent, isOpen, onWidthPercentChange]);
 
-  // Ensure current drawer width respects left+drawer <= 80 when opening or when left column changes
+  // Ensure current drawer width respects left+drawer <= 90 and 45% limit when opening or when left column changes
   React.useEffect(() => {
     if (!isOpen) {
       return;
     }
-    const maxPercent = Math.max(0, 80 - leftColumnPercent);
-    setWidthPercent((prev) => Math.min(prev, maxPercent));
+    const maxPercent = Math.max(0, 90 - leftColumnPercent);
+    const maxPercentWithLimit = Math.min(maxPercent, 45);
+    setWidthPercent((prev) => Math.min(prev, maxPercentWithLimit));
   }, [leftColumnPercent, isOpen]);
 
   if (!isOpen) {

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -12,16 +12,13 @@ interface SpanOverlayDrawerProps {
 /**
  * Easily tunable drawer width constraints
  * Limits are set in both absolute and relative terms
- * The default width is 50% of panel width, but no more than 378px
- * The maximum width is 75% of panel width, but no more than 920px
- * The minimum width is set to 220px
- * The maximum percentage is set to 75%
+ * The default width is 50% of panel width
+ * The minimum width is set to 10% of panel width
+ * The maximum width is set to 75% of panel width
  */
-const DRAWER_MIN_WIDTH_PX = 220; // minimum comfortable width
-const DRAWER_MAX_WIDTH_PX = 920; // maximum absolute width
+const DRAWER_MIN_PERCENT = 10; // minimum comfortable width
 const DRAWER_MAX_PERCENT = 75; // maximum as percentage of panel width
-const DRAWER_DEFAULT_PERCENT = 50; // default as percentage of panel width
-const DRAWER_DEFAULT_PX = 378; // default maximum absolute width
+const DRAWER_DEFAULT_PERCENT = 25; // default as percentage of panel width
 
 export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
   isOpen,
@@ -30,8 +27,8 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
   title = 'Span Details',
   panelWidth,
 }) => {
-  // Default width: up to 50% of panel width, but no more than 378px
-  const defaultWidthPx = Math.min(panelWidth * (DRAWER_DEFAULT_PERCENT / 100), DRAWER_DEFAULT_PX);
+  // Default width: up to 25% of panel width
+  const defaultWidthPx = panelWidth * (DRAWER_DEFAULT_PERCENT / 100);
   const [widthPercent, setWidthPercent] = React.useState<number>((defaultWidthPx / panelWidth) * 100);
   const isResizingRef = React.useRef<boolean>(false);
   const drawerRef = React.useRef<HTMLDivElement | null>(null);
@@ -62,8 +59,8 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         const bounds = container.getBoundingClientRect();
         // Desired width is distance from mouse to the right edge of the container
         const widthPx = Math.max(0, bounds.right - e.clientX);
-        const minPx = DRAWER_MIN_WIDTH_PX; // minimum comfortable width
-        const maxPx = Math.min(bounds.width * (DRAWER_MAX_PERCENT / 100), DRAWER_MAX_WIDTH_PX);
+        const minPx = panelWidth * (DRAWER_MIN_PERCENT / 100); // minimum comfortable width
+        const maxPx = panelWidth * (DRAWER_MAX_PERCENT / 100);
         const clamped = Math.min(Math.max(widthPx, minPx), maxPx);
         const percent = (clamped / bounds.width) * 100;
         setWidthPercent(percent);
@@ -80,7 +77,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
       { signal: controller.signal }
     );
     return () => controller.abort();
-  }, [isOpen]);
+  }, [isOpen, panelWidth]);
 
   const drawerWidth = `${(widthPercent / 100) * panelWidth}px`;
 

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -79,7 +79,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
     return () => controller.abort();
   }, [isOpen, panelWidth]);
 
-  const drawerWidth = `${(widthPercent / 100) * panelWidth}px`;
+  const drawerWidth = React.useMemo(() => `${(widthPercent / 100) * panelWidth}px`, [widthPercent, panelWidth]);
 
   if (!isOpen) {
     return null;

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -54,13 +54,11 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         const widthPx = Math.max(0, bounds.right - e.clientX);
         const minPx = 220; // minimum comfortable width
         const percentRaw = (widthPx / bounds.width) * 100;
-        // Respect overall layout constraint: left + drawer <= 90%
-        const maxPercent = Math.max(0, 90 - leftColumnPercent);
-        // Enforce 50% panel width limit
-        const maxPercentWithLimit = Math.min(maxPercent, 50);
+        // Respect overall layout constraint: left + drawer <= 80%
+        const maxPercent = Math.max(0, 80 - leftColumnPercent);
         // Convert minPx to percent for clamping
         const minPercent = (minPx / bounds.width) * 100;
-        const percent = Math.min(maxPercentWithLimit, Math.max(minPercent, percentRaw));
+        const percent = Math.min(maxPercent, Math.max(minPercent, percentRaw));
         setWidthPercent(percent);
       },
       { signal: controller.signal }
@@ -87,14 +85,13 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
     onWidthPercentChange?.(widthPercent);
   }, [widthPercent, isOpen, onWidthPercentChange]);
 
-  // Ensure current drawer width respects left+drawer <= 90 and 45% limit when opening or when left column changes
+  // Ensure current drawer width respects left+drawer <= 80 when opening or when left column changes
   React.useEffect(() => {
     if (!isOpen) {
       return;
     }
-    const maxPercent = Math.max(0, 90 - leftColumnPercent);
-    const maxPercentWithLimit = Math.min(maxPercent, 45);
-    setWidthPercent((prev) => Math.min(prev, maxPercentWithLimit));
+    const maxPercent = Math.max(0, 80 - leftColumnPercent);
+    setWidthPercent((prev) => Math.min(prev, maxPercent));
   }, [leftColumnPercent, isOpen]);
 
   if (!isOpen) {

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -137,7 +137,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         </div>
 
         {/* Content */}
-        <div className="h-full overflow-y-auto pl-3 pr-1 py-1">{children}</div>
+        <div className="h-full overflow-y-auto pl-2 pr-1 py-1">{children}</div>
       </div>
     </>
   );

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -9,6 +9,20 @@ interface SpanOverlayDrawerProps {
   panelWidth: number;
 }
 
+/**
+ * Easily tunable drawer width constraints
+ * Limits are set in both absolute and relative terms
+ * The default width is 50% of panel width, but no more than 378px
+ * The maximum width is 75% of panel width, but no more than 920px
+ * The minimum width is set to 220px
+ * The maximum percentage is set to 75%
+ */
+const DRAWER_MIN_WIDTH_PX = 220; // minimum comfortable width
+const DRAWER_MAX_WIDTH_PX = 920; // maximum absolute width
+const DRAWER_MAX_PERCENT = 75; // maximum as percentage of panel width
+const DRAWER_DEFAULT_PERCENT = 50; // default as percentage of panel width
+const DRAWER_DEFAULT_PX = 378; // default maximum absolute width
+
 export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
   isOpen,
   onClose,
@@ -17,7 +31,7 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
   panelWidth,
 }) => {
   // Default width: up to 50% of panel width, but no more than 378px
-  const defaultWidthPx = Math.min(panelWidth * 0.5, 378);
+  const defaultWidthPx = Math.min(panelWidth * (DRAWER_DEFAULT_PERCENT / 100), DRAWER_DEFAULT_PX);
   const [widthPercent, setWidthPercent] = React.useState<number>((defaultWidthPx / panelWidth) * 100);
   const isResizingRef = React.useRef<boolean>(false);
   const drawerRef = React.useRef<HTMLDivElement | null>(null);
@@ -48,8 +62,8 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         const bounds = container.getBoundingClientRect();
         // Desired width is distance from mouse to the right edge of the container
         const widthPx = Math.max(0, bounds.right - e.clientX);
-        const minPx = 220; // minimum comfortable width
-        const maxPx = Math.min(bounds.width * 0.7, Math.max(378, bounds.width * 0.3));
+        const minPx = DRAWER_MIN_WIDTH_PX; // minimum comfortable width
+        const maxPx = Math.min(bounds.width * (DRAWER_MAX_PERCENT / 100), DRAWER_MAX_WIDTH_PX);
         const clamped = Math.min(Math.max(widthPx, minPx), maxPx);
         const percent = (clamped / bounds.width) * 100;
         setWidthPercent(percent);

--- a/src/components/Span/SpanOverlayDrawer.tsx
+++ b/src/components/Span/SpanOverlayDrawer.tsx
@@ -7,6 +7,8 @@ interface SpanOverlayDrawerProps {
   children: React.ReactNode;
   title?: string;
   panelWidth: number;
+  onWidthPercentChange?: (percent: number) => void;
+  leftColumnPercent: number;
 }
 
 export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
@@ -15,6 +17,8 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
   children,
   title = 'Span Details',
   panelWidth,
+  onWidthPercentChange,
+  leftColumnPercent,
 }) => {
   // Default width: up to 50% of panel width, but no more than 378px
   const defaultWidthPx = Math.min(panelWidth * 0.5, 378);
@@ -49,9 +53,12 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
         // Desired width is distance from mouse to the right edge of the container
         const widthPx = Math.max(0, bounds.right - e.clientX);
         const minPx = 220; // minimum comfortable width
-        const maxPx = Math.min(bounds.width * 0.7, Math.max(378, bounds.width * 0.3));
-        const clamped = Math.min(Math.max(widthPx, minPx), maxPx);
-        const percent = (clamped / bounds.width) * 100;
+        const percentRaw = (widthPx / bounds.width) * 100;
+        // Respect overall layout constraint: left + drawer <= 80%
+        const maxPercent = Math.max(0, 80 - leftColumnPercent);
+        // Convert minPx to percent for clamping
+        const minPercent = (minPx / bounds.width) * 100;
+        const percent = Math.min(maxPercent, Math.max(minPercent, percentRaw));
         setWidthPercent(percent);
       },
       { signal: controller.signal }
@@ -66,9 +73,26 @@ export const SpanOverlayDrawer: React.FC<SpanOverlayDrawerProps> = ({
       { signal: controller.signal }
     );
     return () => controller.abort();
-  }, [isOpen]);
+  }, [isOpen, leftColumnPercent]);
 
   const drawerWidth = `${(widthPercent / 100) * panelWidth}px`;
+
+  // Notify parent of width percent changes when open
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    onWidthPercentChange?.(widthPercent);
+  }, [widthPercent, isOpen, onWidthPercentChange]);
+
+  // Ensure current drawer width respects left+drawer <= 80 when opening or when left column changes
+  React.useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+    const maxPercent = Math.max(0, 80 - leftColumnPercent);
+    setWidthPercent((prev) => Math.min(prev, maxPercent));
+  }, [leftColumnPercent, isOpen]);
 
   if (!isOpen) {
     return null;

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -277,9 +277,11 @@ function TraceDetail({
         }
         const bounds = container.getBoundingClientRect();
         const relativeX = e.clientX - bounds.left;
-        // Clamp so that left + drawer <= 80% of panel width
-        const maxLeft = Math.max(15, 80 - drawerWidthPercent);
-        const percent = Math.min(maxLeft, Math.max(15, (relativeX / bounds.width) * 100));
+        // Clamp so that left + drawer <= 90% of panel width
+        const maxLeft = Math.max(15, 90 - drawerWidthPercent);
+        // Enforce 45% panel width limit for left column
+        const maxLeftWithLimit = Math.min(maxLeft, 45);
+        const percent = Math.min(maxLeftWithLimit, Math.max(15, (relativeX / bounds.width) * 100));
         setLeftColumnPercent(percent);
       },
       { signal: controller.signal }

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -171,7 +171,6 @@ function TraceDetail({
   const queryKey = ['datasource', datasourceUid, 'trace', traceId];
   const [selectedSpan, setSelectedSpan] = React.useState<SpanInfo | null>(null);
   const [leftColumnPercent, setLeftColumnPercent] = React.useState<number>(25);
-  const [drawerWidthPercent, setDrawerWidthPercent] = React.useState<number>(0);
   const isResizingRef = React.useRef(false);
 
   const idToLevelMap = React.useRef(new Map<string, number>());
@@ -277,9 +276,7 @@ function TraceDetail({
         }
         const bounds = container.getBoundingClientRect();
         const relativeX = e.clientX - bounds.left;
-        // Clamp so that left + drawer <= 80% of panel width
-        const maxLeft = Math.max(15, 80 - drawerWidthPercent);
-        const percent = Math.min(maxLeft, Math.max(15, (relativeX / bounds.width) * 100));
+        const percent = Math.min(80, Math.max(15, (relativeX / bounds.width) * 100));
         setLeftColumnPercent(percent);
       },
       { signal: controller.signal }
@@ -294,7 +291,7 @@ function TraceDetail({
       { signal: controller.signal }
     );
     return () => controller.abort();
-  }, [drawerWidthPercent]);
+  }, []);
 
   const loadRemoteChildren = async (span: SpanInfo) => {
     if (!result.isSuccess) {
@@ -493,8 +490,6 @@ function TraceDetail({
         onClose={() => setSelectedSpan(null)}
         title="Span Details"
         panelWidth={panelWidth || window.innerWidth}
-        leftColumnPercent={leftColumnPercent}
-        onWidthPercentChange={setDrawerWidthPercent}
       >
         {selectedSpan && (
           <SpanDetailPanel span={selectedSpan} onClose={() => setSelectedSpan(null)} datasourceUid={datasourceUid} />

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -277,11 +277,9 @@ function TraceDetail({
         }
         const bounds = container.getBoundingClientRect();
         const relativeX = e.clientX - bounds.left;
-        // Clamp so that left + drawer <= 90% of panel width
-        const maxLeft = Math.max(15, 90 - drawerWidthPercent);
-        // Enforce 45% panel width limit for left column
-        const maxLeftWithLimit = Math.min(maxLeft, 45);
-        const percent = Math.min(maxLeftWithLimit, Math.max(15, (relativeX / bounds.width) * 100));
+        // Clamp so that left + drawer <= 80% of panel width
+        const maxLeft = Math.max(15, 80 - drawerWidthPercent);
+        const percent = Math.min(maxLeft, Math.max(15, (relativeX / bounds.width) * 100));
         setLeftColumnPercent(percent);
       },
       { signal: controller.signal }

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -171,6 +171,7 @@ function TraceDetail({
   const queryKey = ['datasource', datasourceUid, 'trace', traceId];
   const [selectedSpan, setSelectedSpan] = React.useState<SpanInfo | null>(null);
   const [leftColumnPercent, setLeftColumnPercent] = React.useState<number>(25);
+  const [drawerWidthPercent, setDrawerWidthPercent] = React.useState<number>(0);
   const isResizingRef = React.useRef(false);
 
   const idToLevelMap = React.useRef(new Map<string, number>());
@@ -276,7 +277,9 @@ function TraceDetail({
         }
         const bounds = container.getBoundingClientRect();
         const relativeX = e.clientX - bounds.left;
-        const percent = Math.min(80, Math.max(15, (relativeX / bounds.width) * 100));
+        // Clamp so that left + drawer <= 80% of panel width
+        const maxLeft = Math.max(15, 80 - drawerWidthPercent);
+        const percent = Math.min(maxLeft, Math.max(15, (relativeX / bounds.width) * 100));
         setLeftColumnPercent(percent);
       },
       { signal: controller.signal }
@@ -291,7 +294,7 @@ function TraceDetail({
       { signal: controller.signal }
     );
     return () => controller.abort();
-  }, []);
+  }, [drawerWidthPercent]);
 
   const loadRemoteChildren = async (span: SpanInfo) => {
     if (!result.isSuccess) {
@@ -490,6 +493,8 @@ function TraceDetail({
         onClose={() => setSelectedSpan(null)}
         title="Span Details"
         panelWidth={panelWidth || window.innerWidth}
+        leftColumnPercent={leftColumnPercent}
+        onWidthPercentChange={setDrawerWidthPercent}
       >
         {selectedSpan && (
           <SpanDetailPanel span={selectedSpan} onClose={() => setSelectedSpan(null)} datasourceUid={datasourceUid} />


### PR DESCRIPTION
Improves the span overlay drawer by enabling users to resize it via a draggable handle.

- Adds resizing functionality to the span overlay drawer for a better user experience.
- Ensures the drawer respects layout constraints by limiting its width based on the left column's size.

<img width="1608" height="616" alt="image" src="https://github.com/user-attachments/assets/9c0d2770-a6bb-47e4-bd12-bc3063265525" />
