### PR TITLE
Adds collapse all spans functionality

### DIFF
--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -367,6 +367,22 @@ function TraceDetail({
     });
   };
 
+  const collapseAll = () => {
+    queryClient.setQueryData<SpanInfo[]>(queryKey, (oldData) => {
+      if (!oldData) {
+        return oldData;
+      }
+
+      return oldData.map((sp) => {
+        // Only collapse spans that have children and are currently showing them
+        if (sp.childStatus === ChildStatus.ShowChildren && sp.childCount && sp.childCount > 0) {
+          return { ...sp, childStatus: ChildStatus.HideChildren };
+        }
+        return sp;
+      });
+    });
+  };
+
   const virtualItems = rowVirtualizer.getVirtualItems();
 
   function copyData() {
@@ -396,6 +412,7 @@ function TraceDetail({
             timeRange={timeRange}
             leftColumnPercent={leftColumnPercent}
             onDividerMouseDown={onMouseDownDivider}
+            onCollapseAll={collapseAll}
           />
         </div>
         <div className={`flex-grow py-2`} data-testid={testIds.pageThree.container}>

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -397,6 +397,10 @@ function TraceDetail({
     navigator.clipboard.writeText(JSON.stringify(striped));
   }
 
+  // Check if there are any expanded spans that can be collapsed
+  const hasExpandedSpans =
+    result.isSuccess && result.data.some((span) => span.childStatus === ChildStatus.ShowChildren);
+
   return (
     // Grafana sets padding on the parent panel which causes our content to overflow.
     // This negative margin compensates for that padding to keep content within bounds.
@@ -413,6 +417,7 @@ function TraceDetail({
             leftColumnPercent={leftColumnPercent}
             onDividerMouseDown={onMouseDownDivider}
             onCollapseAll={collapseAll}
+            hasExpandedSpans={hasExpandedSpans}
           />
         </div>
         <div className={`flex-grow py-2`} data-testid={testIds.pageThree.container}>

--- a/src/components/TraceViewerHeader.tsx
+++ b/src/components/TraceViewerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TraceViewerHeaderProps } from '../types';
-import { Button, Icon } from '@grafana/ui';
+import { Button, Icon, IconButton } from '@grafana/ui';
 // removed unused Help/Info imports after replacing with resize handle
 import { isDark } from '../utils/utils.url';
 
@@ -125,19 +125,17 @@ export const TraceViewerHeader = ({
             </div>
           </div>
           {/* Collapse All Button */}
-          {hasExpandedSpans && (
-            <div className="px-3 py-1">
-              <Button
-                variant="secondary"
-                fill="text"
-                size="sm"
-                onClick={onCollapseAll}
-                title="Collapse all expanded spans"
-              >
-                <Icon name="table-collapse-all" />
-              </Button>
-            </div>
-          )}
+          <div className="px-3 py-1">
+            <IconButton
+              variant="secondary"
+              name="table-collapse-all"
+              size="sm"
+              onClick={onCollapseAll}
+              title="Collapse all expanded spans"
+              disabled={!hasExpandedSpans}
+              aria-label="Collapse all expanded spans"
+            />
+          </div>
         </div>
         <div className="font-bold px-4" style={{ width: `${100 - leftColumnPercent}%` }}>
           <div className="w-full relative">

--- a/src/components/TraceViewerHeader.tsx
+++ b/src/components/TraceViewerHeader.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { TraceViewerHeaderProps } from '../types';
+import { Button } from '@grafana/ui';
 // removed unused Help/Info imports after replacing with resize handle
 import { isDark } from '../utils/utils.url';
 
@@ -12,6 +13,7 @@ export const TraceViewerHeader = ({
   timeRange,
   leftColumnPercent,
   onDividerMouseDown,
+  onCollapseAll,
 }: TraceViewerHeaderProps) => {
   function copyTraceId() {
     navigator.clipboard.writeText(traceId);
@@ -120,6 +122,12 @@ export const TraceViewerHeader = ({
                 <span className={`${textColour}`}>{formatDuration(durationInMs)}</span>
               </div>
             </div>
+          </div>
+          {/* Collapse All Button */}
+          <div className="px-3 py-1">
+            <Button variant="secondary" size="sm" onClick={onCollapseAll} title="Collapse all expanded spans">
+              Collapse All
+            </Button>
           </div>
         </div>
         <div className="font-bold px-4" style={{ width: `${100 - leftColumnPercent}%` }}>

--- a/src/components/TraceViewerHeader.tsx
+++ b/src/components/TraceViewerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TraceViewerHeaderProps } from '../types';
-import { Button, Icon, IconButton } from '@grafana/ui';
+import { IconButton } from '@grafana/ui';
 // removed unused Help/Info imports after replacing with resize handle
 import { isDark } from '../utils/utils.url';
 

--- a/src/components/TraceViewerHeader.tsx
+++ b/src/components/TraceViewerHeader.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { TraceViewerHeaderProps } from '../types';
-import { Button } from '@grafana/ui';
+import { Button, Icon } from '@grafana/ui';
 // removed unused Help/Info imports after replacing with resize handle
 import { isDark } from '../utils/utils.url';
 
@@ -14,6 +14,7 @@ export const TraceViewerHeader = ({
   leftColumnPercent,
   onDividerMouseDown,
   onCollapseAll,
+  hasExpandedSpans = false,
 }: TraceViewerHeaderProps) => {
   function copyTraceId() {
     navigator.clipboard.writeText(traceId);
@@ -124,11 +125,19 @@ export const TraceViewerHeader = ({
             </div>
           </div>
           {/* Collapse All Button */}
-          <div className="px-3 py-1">
-            <Button variant="secondary" size="sm" onClick={onCollapseAll} title="Collapse all expanded spans">
-              Collapse All
-            </Button>
-          </div>
+          {hasExpandedSpans && (
+            <div className="px-3 py-1">
+              <Button
+                variant="secondary"
+                fill="text"
+                size="sm"
+                onClick={onCollapseAll}
+                title="Collapse all expanded spans"
+              >
+                <Icon name="table-collapse-all" />
+              </Button>
+            </div>
+          )}
         </div>
         <div className="font-bold px-4" style={{ width: `${100 - leftColumnPercent}%` }}>
           <div className="w-full relative">

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,4 +32,5 @@ export type TraceViewerHeaderProps = {
   leftColumnPercent: number;
   onDividerMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
   onCollapseAll: () => void;
+  hasExpandedSpans?: boolean;
 };

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,4 +31,5 @@ export type TraceViewerHeaderProps = {
   timeRange: TimeRange;
   leftColumnPercent: number;
   onDividerMouseDown: (e: React.MouseEvent<HTMLDivElement>) => void;
+  onCollapseAll: () => void;
 };


### PR DESCRIPTION
Implements a "Collapse All" button in the trace viewer header.

This allows users to easily collapse all expanded spans in the trace view,
improving readability and navigation, especially for traces with many
expanded spans.

<img width="521" height="286" alt="image" src="https://github.com/user-attachments/assets/1dc2cba1-0472-4c23-8933-9c1e8e94b255" />

The icon is from grafana ui icons. It is not identical to the one in the design, but it should be close enough. If needed, we could probably add an SVG of the exact icon.
