### PR TITLE
Wraps value and copy in table row

### DIFF
--- a/src/components/Span/SpanDetailsPanel.tsx
+++ b/src/components/Span/SpanDetailsPanel.tsx
@@ -113,23 +113,27 @@ function ValueWrapper({
 }) {
   const [tooltip, setTooltip] = useState('Copy value');
   return (
-    <span className={`flex gap-1 items-center justify-between ${italic ? 'italic' : ''}`}>
-      <span className={`p-2 ${color}`}>{displayValue || value}</span>
-      <IconButton
-        name="copy"
-        variant="secondary"
-        aria-label="Copy value"
-        className="bg-red-500"
-        tooltip={tooltip}
-        onClick={() => {
-          navigator.clipboard.writeText(value || '');
-          setTooltip((_) => 'Copied!');
-          setTimeout(() => {
-            setTooltip((_) => 'Copy value');
-          }, 1000);
-        }}
-      />
-    </span>
+    <tr>
+      <td className={`max-w-[1px] w-full ${italic ? 'italic' : ''}`}>
+        <span className={`block truncate p-2 ${color}`}>{displayValue || value}</span>
+      </td>
+      <td>
+        <IconButton
+          name="copy"
+          variant="secondary"
+          aria-label="Copy value"
+          className="bg-red-500"
+          tooltip={tooltip}
+          onClick={() => {
+            navigator.clipboard.writeText(value || '');
+            setTooltip((_) => 'Copied!');
+            setTimeout(() => {
+              setTooltip((_) => 'Copy value');
+            }, 1000);
+          }}
+        />
+      </td>
+    </tr>
   );
 }
 


### PR DESCRIPTION
Wraps the displayed value and copy button within a table row.

This change is likely to improve layout and alignment, particularly within a larger table or grid structure. It allows for better control over the positioning of the value and the copy button relative to other elements.