### PR TITLE
Enhances GR Trace Viewer dashboard

### DIFF
--- a/provisioning/dashboards/gr-dashboard.json
+++ b/provisioning/dashboards/gr-dashboard.json
@@ -51,7 +51,26 @@
             ]
           }
         },
-        "overrides": []
+        "overrides": [
+          {
+            "matcher": {
+              "id": "byName",
+              "options": "Trace ID"
+            },
+            "properties": [
+              {
+                "id": "links",
+                "value": [
+                  {
+                    "title": "Set trace ID",
+                    "url": "/d/gr-trace-viewer-dashboard?var-traceId=${__data.fields.traceID}&${__url_time_range}",
+                    "targetBlank": false
+                  }
+                ]
+              }
+            ]
+          }
+        ]
       },
       "gridPos": {
         "h": 12,
@@ -84,7 +103,7 @@
           "metricsQueryType": "range",
           "query": "{}",
           "queryType": "traceql",
-          "refId": "A",
+          "refId": "Auto",
           "tableType": "traces"
         }
       ],
@@ -117,9 +136,9 @@
           },
           "limit": 20,
           "metricsQueryType": "range",
-          "query": "{}",
+          "query": "{trace:id=\"${traceId}\"}",
           "queryType": "traceql",
-          "refId": "A",
+          "refId": "Auto",
           "tableType": "traces"
         }
       ],
@@ -131,14 +150,34 @@
   "schemaVersion": 41,
   "tags": ["plugin", "traces"],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": "",
+        "current": {
+          "selected": false,
+          "text": "",
+          "value": ""
+        },
+        "description": "Selected trace ID from table click",
+        "hide": 0,
+        "includeAll": false,
+        "label": "Trace ID",
+        "multi": false,
+        "name": "traceId",
+        "options": [],
+        "query": "",
+        "queryValue": "",
+        "skipUrlSync": false,
+        "type": "textbox"
+      }
+    ]
   },
   "time": {
     "from": "now-7d",
     "to": "now"
   },
   "timepicker": {},
-  "timezone": "browser",
+  "timezone": "",
   "title": "GR Incremental Trace Viewer",
   "uid": "gr-trace-viewer-dashboard",
   "version": 1


### PR DESCRIPTION
Adds functionality to the GR Trace Viewer dashboard:

- Enables users to navigate to a detailed trace view by clicking on a Trace ID within the table panel.
- Introduces a `traceId` variable to dynamically filter traces based on the selected ID.

**Changes:**
- Trace ID is now a variable, and is shown on the top bar (user can copy->paste Trace ID from anywhere)
- Nothing is loaded by default on the trace viewer, but table data is populated with available trace IDs
- Clicking Trace ID populates the Trace ID field and loads data in the trace viewer
- Sharing the URL to the dashboard can include the Trace ID, and it will be selected & loaded inthe  trace viewer

<img width="1351" height="831" alt="Screenshot 2025-08-19 at 20 25 17" src="https://github.com/user-attachments/assets/b2a16bd0-87e2-4048-bdb6-18dfb9f0f8b9" />

<img width="1351" height="831" alt="Screenshot 2025-08-19 at 20 25 41" src="https://github.com/user-attachments/assets/37eaa0bd-1b7f-478b-a839-c9602aaae705" />
