### PR TITLE
Increase dataproxy timeout

### DIFF
--- a/.config/docker-compose-base.yaml
+++ b/.config/docker-compose-base.yaml
@@ -22,6 +22,7 @@ services:
       - ../dist:/var/lib/grafana/plugins/gresearch-grafanaincrementaltraceviewer-panel
       - ../provisioning:/etc/grafana/provisioning
       - ..:/root/gresearch-grafanaincrementaltraceviewer-panel
+      - ./grafana.ini:/etc/grafana/grafana.ini
 
     environment:
       NODE_ENV: development

--- a/.config/grafana.ini
+++ b/.config/grafana.ini
@@ -1,0 +1,2 @@
+[dataproxy]
+timeout = 3600


### PR DESCRIPTION
Turns out #97 was limited by Grafana.
Both the browser, nor TanStack has a known limit really.