### PR TITLE
Conditionally Enables Trace Details Scroll

### DIFF
--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -441,7 +441,7 @@ function TraceDetail({
           )}
           {result.isError && <div>Error: {result.error.message}</div>}
           {result.isSuccess && (
-            <div ref={parentRef} className="overflow-auto h-full">
+            <div ref={parentRef} className={`${selectedSpan ? 'overflow-hidden' : 'overflow-auto'} h-full`}>
               <div
                 style={{
                   height: `${rowVirtualizer.getTotalSize()}px`,


### PR DESCRIPTION
Addresses an issue where the trace details scroll was unintentionally disabled when details were open.

- Updates the trace details component to conditionally enable scrolling based on whether a specific span is selected.
- Ensures that the scroll is only disabled when a span's details are being viewed.