### PR TITLE
Add full value in title attributes

### DIFF
--- a/src/components/Span/Span.tsx
+++ b/src/components/Span/Span.tsx
@@ -76,7 +76,7 @@ export const Span = (props: SpanNodeProps) => {
           minWidth: 0,
         }} // Limitation in tailwind dynamic class construction: Check README.md for more details
       >
-        <div className="flex items-center gap-1 truncate">
+        <div className="flex items-center gap-1 truncate" title={`${props.serviceName} - ${props.name}`}>
           <Expand childStatus={props.childStatus} action={() => props.updateChildStatus(props)}></Expand>
 
           <strong

--- a/src/components/Span/SpanDetailsPanel.tsx
+++ b/src/components/Span/SpanDetailsPanel.tsx
@@ -113,7 +113,7 @@ function ValueWrapper({
 }) {
   const [tooltip, setTooltip] = useState('Copy value');
   return (
-    <tr>
+    <tr title={displayValue || value}>
       <td className={`max-w-[1px] w-full ${italic ? 'italic' : ''}`}>
         <span className={`block truncate p-2 ${color}`}>{displayValue || value}</span>
       </td>


### PR DESCRIPTION
I think it is important that we always provide a way to show the full name or value to the user.

<img width="489" height="305" alt="image" src="https://github.com/user-attachments/assets/2950b585-5732-49e5-ac15-616cafb30a13" />

<img width="596" height="329" alt="image" src="https://github.com/user-attachments/assets/4a241d1a-7f5a-453d-8031-bb039ddeee18" />

Tooltip would be too intrusive, so I went with title.