### PR TITLE
Removes backend getting started guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,27 +33,6 @@ SUPPORTS_CHILD_COUNT=0
 
 ## Get started
 
-### Backend
-
-1. Update [Grafana plugin SDK for Go](https://grafana.com/developers/plugin-tools/key-concepts/backend-plugins/grafana-plugin-sdk-for-go) dependency to the latest minor version:
-
-   ```bash
-   go get -u github.com/grafana/grafana-plugin-sdk-go
-   go mod tidy
-   ```
-
-2. Build backend plugin binaries for Linux, Windows and Darwin:
-
-   ```bash
-   mage -v
-   ```
-
-3. List all available Mage targets for additional commands:
-
-   ```bash
-   mage -l
-   ```
-
 ### Frontend
 
 1. Install dependencies


### PR DESCRIPTION
Removes the backend getting started guide from the README.

The backend guide is outdated and no longer relevant.
