### PR TITLE
Clean up release-detect

### DIFF
--- a/.github/workflows/release-check.yml
+++ b/.github/workflows/release-check.yml
@@ -30,7 +30,7 @@ jobs:
           # Being explicit here as we want to avoid any dry run
           CI: true
         run: |
-          bun run ./scripts/release-detect.js
+          bun run ./scripts/release-detect.ts
           EXIT_CODE=$?
           if [ $EXIT_CODE -eq 2 ]; then
             echo "No new release needed - stopping workflow"


### PR DESCRIPTION
As we only care for the exitcode, there is no need to `--dry-run` really.