### PR TITLE
Use span:childCount intrinsic and drop the dual-mode toggle.

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -193,11 +193,6 @@ const config = async (env: Env): Promise<Configuration> => {
     plugins: [
       new BuildModeWebpackPlugin(),
       virtualPublicPath,
-      // Define environment variable for setting default panel option value
-      // Default is true (child count enabled). Set SUPPORTS_CHILD_COUNT=0 to disable.
-      new webpack.DefinePlugin({
-        'process.env.SUPPORTS_CHILD_COUNT': process.env.SUPPORTS_CHILD_COUNT !== '0',
-      }),
       // Insert create plugin version information into the bundle
       new webpack.BannerPlugin({
         banner: '/* [create-plugin] version: ' + cpVersion + ' */',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -149,8 +149,8 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
-      - name: Build plugin (without child count for standard Tempo tests)
-        run: bun run build:without-child-count
+      - name: Build plugin
+        run: bun run build
 
       - name: Start Grafana
         run: |
@@ -186,26 +186,23 @@ jobs:
       - name: Stop grafana docker (after regular tests)
         run: docker compose down
 
-      - name: Build plugin (with child count, default)
-        run: bun run build
-
-      - name: Start Grafana (for child count tests)
+      - name: Start Grafana (for G-Research custom API tests)
         run: |
           docker compose -f ./local-tempo-docker-compose.yml pull
           ANONYMOUS_AUTH_ENABLED=false DEVELOPMENT=false GRAFANA_VERSION=${{ matrix.GRAFANA_IMAGE.VERSION }} GRAFANA_IMAGE=${{ matrix.GRAFANA_IMAGE.NAME }} docker compose -f ./local-tempo-docker-compose.yml up --build -d
 
-      - name: Wait for grafana server (child count)
+      - name: Wait for grafana server (G-Research custom API)
         uses: grafana/plugin-actions/wait-for-grafana@main # zizmor: ignore[unpinned-uses] provided by grafana
         with:
           url: http://localhost:3000/login
 
-      - name: Start server with child count support
+      - name: Start G-Research custom API test server
         run: |
           bun run tests/test-api.ts &
           echo $! > /tmp/test-api.pid
           echo "Started test API server with PID: $(cat /tmp/test-api.pid)"
 
-      - name: Run Playwright tests (with child count)
+      - name: Run Playwright tests (G-Research custom API)
         id: run-tests-child-count
         run: bun run e2e
 
@@ -221,14 +218,14 @@ jobs:
             echo "No test API server PID file found"
           fi
 
-      - name: Upload e2e test summary (with child count)
+      - name: Upload e2e test summary (G-Research custom API)
         uses: grafana/plugin-actions/playwright-gh-pages/upload-report-artifacts@main # zizmor: ignore[unpinned-uses] provided by grafana
         if: ${{ always() && !cancelled() }}
         with:
           upload-report: false
           github-token: ${{ secrets.GITHUB_TOKEN }}
           test-outcome: ${{ steps.run-tests-child-count.outcome }}
-          plugin-name: gresearch-grafanaincrementaltraceviewer-panel-0.2.0-with-child-count
+          plugin-name: gresearch-grafanaincrementaltraceviewer-panel-gresearch-custom-api
 
       - name: Docker logs
         if: ${{ always() && (steps.run-tests-regular.outcome == 'failure' || steps.run-tests-child-count.outcome == 'failure') }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,18 @@
 # Changelog
 
+## [0.4.0] - 2026-06-02
+
+### Changed
+
+- Migrated child-count retrieval to Tempo's `span:childCount` TraceQL intrinsic. The plugin now always requests `| select(span:name, resource.service.name, span:childCount)` and reads the count inline. This **requires Grafana Tempo >= 2.10 with the vParquet5 block encoding** (or the G-Research custom Tempo API, which also returns `span:childCount`). The previous bare `childCount` select is now a syntax error on Tempo >= 2.10, so this also fixes that breakage.
+- Removed the per-span `count()` fallback query for child counts. Because counts are now returned inline, the previous N+1 fan-out is gone.
+- The span detail panel now detects at runtime whether the backend returns all attributes inline (G-Research custom API) versus only the selected ones (standard Tempo), instead of relying on a panel option.
+
+### Removed
+
+- Removed the "Enable G-Research Tempo API support" panel option (`supportsChildCount`). Both backends are now handled by a single build with runtime feature detection, so no per-panel configuration is required.
+- Removed the `build:without-child-count` and `dev:without-child-count` scripts and the `SUPPORTS_CHILD_COUNT` build-time environment variable. Use `bun run build` / `bun run dev` for all builds.
+
 ## [0.3.0] - 2026-06-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -19,33 +19,14 @@ For detailed usage instructions and troubleshooting, see [HELP.md](HELP.md).
 
 App plugins can let you create a custom out-of-the-box monitoring experience by custom pages, nested data sources and panel plugins.
 
-## Panel Configuration
+## Backend requirements
 
-The plugin supports runtime configuration through panel options. To configure the setting:
+The plugin works against both standard Grafana Tempo and the G-Research custom Tempo API with a **single build and no panel configuration**:
 
-1. Create or edit a panel using this plugin on a dashboard
-2. In the panel edit mode, look for the "Enable G-Research Tempo API support" option in the panel options panel (right sidebar)
-3. Toggle the setting as needed
+- **Child count** is requested inline via the `span:childCount` TraceQL intrinsic ([grafana/tempo#5311](https://github.com/grafana/tempo/issues/5311#issuecomment-3119494111)). This requires **Grafana Tempo >= 2.10 written in the vParquet5 block encoding** (vParquet5 is opt-in in Tempo 2.10.x; the default vParquet4 does not expose `span:childCount`). The G-Research custom Tempo API returns the same `span:childCount` value.
+- **Span attributes** for the detail panel are resolved automatically: the plugin detects at runtime whether the backend returns every attribute inline (G-Research custom API) or only the attributes named in `select(...)` (standard Tempo), and fetches the remainder via `/search/tags` only when needed.
 
-**Setting**: Enable G-Research Tempo API support
-
-- A boolean setting that controls whether the plugin uses child count support for G-Research custom Tempo API. When enabled, the plugin will use `childCount` attributes from the backend. When disabled, it works with the standard Grafana Tempo API.
-
-### Development Default
-
-By default, child count support is **enabled** (for G-Research custom Tempo API). For local development with standard Grafana Tempo API, you can disable it:
-
-```bash
-# Default: child count enabled (for G-Research custom Tempo API)
-bun run dev
-
-# Disable for standard Grafana Tempo API
-SUPPORTS_CHILD_COUNT=0 bun run dev
-# Or use the convenience script:
-bun run dev:without-child-count
-```
-
-This sets the default value for new panels, but you can still override it per panel in the UI.
+There are no panel options to configure — just add the panel and point it at a Tempo-compatible data source.
 
 ## Get started
 
@@ -250,13 +231,10 @@ In production at G-Research, we target a Tempo-compatible API endpoint. The API 
 
 Minor differences:
 
-- The `search` endpoint returns all span attributes, even when they were not requested in traceQL. When opening span details the client performs two requests to obtain all span attributes:
+- The `search` endpoint returns all span attributes, even when they were not requested in traceQL. The Grafana Tempo API only returns attributes which are part of the `| select(...)` query, so for standard Tempo the client performs two extra requests to obtain all span attributes when opening span details:
   1. Retrieve all tags via `/search/tags`.
   2. Query the span and use the tags in a `select(...)`.
-     The Grafana Tempo API only returns attributes which are part of the `| select(...)` query.
-     In production, the server already has these attributes and we do not fetch them again.
-
-- `childCount` is part of the traceQL spec but is not implemented by Grafana Tempo. ([comment](https://github.com/grafana/tempo/issues/5311#issuecomment-3119494111)) This field is supported by the production API.
+     The plugin detects which behaviour applies at runtime: if the initial search already returned attributes beyond the selected/structural ones, it reads them inline and skips the two extra requests.
 
 - In traceQL, `nestedSetParent = -1` is an undocumented feature (but part of the spec) used to find root nodes.
   Ideally, each trace has a single root node; however, when a trace is still in progress, that root node might not yet exist (see partial application spans).
@@ -269,13 +247,13 @@ Check if "applicationUrl" in `launchSettings.json` has this.
 
 ## API discrepancies
 
-To differentiate between the Grafana Tempo API and the G-Research–flavoured Tempo API, the plugin uses a panel setting called "Enable G-Research Tempo API support". When enabled, the plugin will use the G-Research custom API features like child count support. When disabled, it works with the standard Grafana Tempo API.
+The plugin targets both the standard Grafana Tempo API and the G-Research–flavoured Tempo API from a single build. It uses the same query form for both (`select(span:name, resource.service.name, span:childCount)`) and detects the backend's behaviour at runtime — there is no panel setting to toggle. Standard Tempo must be **>= 2.10 on vParquet5** for `span:childCount` to be available.
 
 ## Testing
 
 We run end-to-end using Playwright and `@grafana/plugin-e2e`.
 There are two ways to run the tests, depending on which API you want to test against (standard Grafana Tempo API or G-Research custom API).
-In both cases, we rely on a provisioned Docker compose setup.
+The same plugin build is used for both; we rely on a provisioned Docker compose setup in each case.
 
 **Playwright requires Chromium as a dependency**
 
@@ -290,15 +268,15 @@ Chromium cannot be installed in our production environment, so we do not include
 ### Standard Grafana Tempo API
 
 Run `bun run server` to start the regular developer setup.  
-Here we shall target the Grafana Tempo API as mentioned in [./docker-compose.yaml].
+Here we shall target the Grafana Tempo API as mentioned in [./docker-compose.yaml]. The Tempo service is pinned to a version (>= 2.10) and `tempo-config.yaml` is configured for the **vParquet5** block encoding, which is required for the `span:childCount` intrinsic.
 
 Run
 
 ```shell
-bun run build:without-child-count
+bun run build
 ```
 
-to build the plugin without child count support (for standard Grafana Tempo API). When creating or editing a panel on a dashboard, make sure "Enable G-Research Tempo API support" is disabled in the panel options.
+to build the plugin. No per-panel configuration is needed — the plugin detects child-count and attribute support at runtime.
 
 Next, we need to provision sample data to our Tempo store.
 Run
@@ -335,13 +313,11 @@ In production, this would be the .NET side of things, for our local setup, we ca
 bun run tests/test-api.ts
 ```
 
-Next, build our plugin (default has child count enabled):
+Next, build our plugin (the same build works for this setup):
 
 ```shell
 bun run build
 ```
-
-The default panel option will have "Enable G-Research Tempo API support" enabled, which is correct for this setup.
 
 Afterwards, you should be able to run the tests using:
 

--- a/package.json
+++ b/package.json
@@ -1,11 +1,9 @@
 {
   "name": "grafana-incremental-trace-viewer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "build:without-child-count": "SUPPORTS_CHILD_COUNT=0 webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
-    "dev:without-child-count": "SUPPORTS_CHILD_COUNT=0 webpack -w -c ./.config/webpack/webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",

--- a/scripts/extract-trace.ts
+++ b/scripts/extract-trace.ts
@@ -84,13 +84,13 @@ async function addAttributesToSpan(trace: Trace, span: Span) {
     });
   }
 
-  // Add childCount
+  // Add span:childCount (the TraceQL intrinsic key returned by Tempo >= 2.10 / the G-Research API)
   const childCount = trace.spanSets?.[0].spans?.filter(
     (s) => s.attributes?.find((attr) => attr.key === 'span:parentID')?.value?.stringValue === span.spanID
   ).length;
   if (childCount !== undefined) {
     span.attributes?.push({
-      key: 'childCount',
+      key: 'span:childCount',
       value: {
         intValue: childCount.toString(),
       },

--- a/src/components/Span/SpanDetailsPanel.tsx
+++ b/src/components/Span/SpanDetailsPanel.tsx
@@ -136,12 +136,12 @@ export function SpanDetailPanel({
   span,
   onClose,
   fetchFn,
-  supportsChildCount,
+  attributesInline,
 }: {
   span: SpanInfo;
   onClose: () => void;
   fetchFn: FetchFunction<any>;
-  supportsChildCount: boolean;
+  attributesInline: boolean;
 }) {
   const [expandedSections, setExpandedSections] = useState({
     additionalData: false,
@@ -162,7 +162,10 @@ export function SpanDetailPanel({
   const result = useQuery<TagAttributes>({
     queryKey: ['trace', span.traceId, 'span', span.spanId, 'details'],
     queryFn: async () => {
-      if (supportsChildCount) {
+      // When the backend already returns every attribute inline (G-Research custom API), we
+      // can read them locally. Standard Tempo only returns the selected attributes, so we
+      // fetch the full set in a separate two-step request.
+      if (attributesInline) {
         return collectTagAttributes(span.attributes);
       }
 

--- a/src/components/TraceDetail.tsx
+++ b/src/components/TraceDetail.tsx
@@ -34,28 +34,31 @@ function getParentSpanId(span: Span): string | null {
   return parentSpanId || null;
 }
 
-async function fetchChildCountViaAPI(
-  fetchFn: FetchFunction<SearchResponse>,
-  traceId: string,
-  spanId: string,
-  startTimeUnixNano: number,
-  endTimeUnixNano: number
-): Promise<number | undefined> {
-  const q = `{ trace:id = "${traceId}" && span:parentID = "${spanId}" } | count() > 0`;
-  const start = mkUnixEpochFromNanoSeconds(startTimeUnixNano);
-  // As a precaution, we add 1 second to the end time.
-  // This is to avoid any rounding errors where the microseconds or nanoseconds are not included in the end time.
-  const end = mkUnixEpochFromNanoSeconds(endTimeUnixNano) + 1;
-  const data = await search(fetchFn, q, start, end, 1);
-  return data.traces?.[0]?.spanSets?.[0]?.matched;
+// Attribute keys that Tempo returns for our `select(...)` queries regardless of the
+// user's own attributes: the fields we explicitly select plus the structural intrinsics
+// Tempo includes automatically. We use these to detect whether a backend already returns
+// every attribute inline (G-Research custom API) or only the selected ones (standard Tempo).
+const STRUCTURAL_ATTRIBUTE_KEYS = new Set([
+  'span:name',
+  'name',
+  'service.name',
+  'resource.service.name',
+  'span:parentID',
+  'nestedSetParent',
+  'span:childCount',
+]);
+
+// Standard Grafana Tempo only returns the attributes listed in `select(...)`, so the span
+// detail panel must fetch the rest in a separate two-step request. The G-Research custom API
+// instead returns every attribute inline. We detect which one we are talking to by checking
+// whether the search response carries any attribute beyond the structural/selected set.
+function backendReturnsAttributesInline(spans: Span[]): boolean {
+  return spans.some((span) =>
+    (span.attributes || []).some((a) => a.key != null && !STRUCTURAL_ATTRIBUTE_KEYS.has(a.key))
+  );
 }
 
-async function extractSpans(
-  fetchFn: FetchFunction<SearchResponse>,
-  idToLevelMap: Map<string, number>,
-  traceId: string,
-  responseData: SearchResponse
-): Promise<SpanInfo[]> {
+function extractSpans(idToLevelMap: Map<string, number>, traceId: string, responseData: SearchResponse): SpanInfo[] {
   const trace = responseData.traces?.find((t) => t.traceID === traceId);
   if (!trace) {
     // The trace might not have results for the current query.
@@ -97,16 +100,11 @@ async function extractSpans(
     const startTimeUnixNano = parseInt(span.startTimeUnixNano || '0', 10);
     const durationNanos = parseInt(span.durationNanos || '0', 10);
     const endTimeUnixNano = startTimeUnixNano + durationNanos;
-    // This is a rather expensive call.
-    // We need to call this for every span.
-    // Assuming that the childCount is set by the backend.
-    // We can just use that value to determine if the span has more children.
-    let childCountRaw = span.attributes?.find((a) => a.key === 'childCount')?.value?.intValue;
-    let childCount = childCountRaw === undefined ? undefined : parseInt(childCountRaw as string, 10);
-    if (childCount === undefined) {
-      // If not, we need to fetch the children count via additional query.
-      childCount = await fetchChildCountViaAPI(fetchFn, traceId, span.spanID, startTimeUnixNano, endTimeUnixNano);
-    }
+    // The number of direct children is returned inline by the backend via the
+    // `span:childCount` TraceQL intrinsic (Tempo >= 2.10 on vParquet5, and the G-Research
+    // custom Tempo API).
+    const childCountRaw = span.attributes?.find((a) => a.key === 'span:childCount')?.value?.intValue;
+    const childCount = childCountRaw === undefined ? undefined : parseInt(childCountRaw as string, 10);
 
     const serviceName = span.attributes?.find((a) => a.key === 'service.name')?.value?.stringValue || undefined;
 
@@ -140,18 +138,16 @@ async function extractSpans(
   return spans;
 }
 
-function getPipeSelect(supportsChildCount: boolean): string {
-  return `| select (span:name, resource.service.name${supportsChildCount ? ', childCount' : ''})`;
-}
+// The child count is requested inline via the `span:childCount` TraceQL intrinsic, which
+// requires Tempo >= 2.10 written in vParquet5 (or the G-Research custom Tempo API).
+const pipeSelect = `| select (span:name, resource.service.name, span:childCount)`;
 
 async function loadMoreSpans(
   fetchFn: FetchFunction<SearchResponse>,
   traceId: string,
   idToLevelMap: Map<string, number>,
-  span: SpanInfo,
-  supportsChildCount: boolean
+  span: SpanInfo
 ): Promise<SpanInfo[]> {
-  const pipeSelect = getPipeSelect(supportsChildCount);
   const q = `{ trace:id = "${traceId}" && span:parentID = "${span.spanId}" } ${pipeSelect}`;
   const start = mkUnixEpochFromNanoSeconds(span.startTimeUnixNano);
   // As a precaution, we add 1 second to the end time.
@@ -159,7 +155,7 @@ async function loadMoreSpans(
   const end = mkUnixEpochFromNanoSeconds(span.endTimeUnixNano) + 1;
   // See https://github.com/grafana/tempo/issues/5435
   const data = await search(fetchFn, q, start, end, 4294967295);
-  return await extractSpans(fetchFn, idToLevelMap, traceId, data);
+  return extractSpans(idToLevelMap, traceId, data);
 }
 
 function TraceDetail({
@@ -170,8 +166,7 @@ function TraceDetail({
   panelWidth,
   panelHeight,
   timeRange,
-  supportsChildCount,
-}: TraceDetailProps & { timeRange: TimeRange; supportsChildCount: boolean }): React.JSX.Element {
+}: TraceDetailProps & { timeRange: TimeRange }): React.JSX.Element {
   // Should we assert for traceId and datasourceId?
   if (!traceId || !datasourceUid) {
     throw new Error('traceId and datasourceId are required');
@@ -189,6 +184,10 @@ function TraceDetail({
   const fetchFn = React.useMemo(() => searchWithDatasourceUid<SearchResponse>(datasourceUid), [datasourceUid]);
 
   const idToLevelMap = React.useRef(new Map<string, number>());
+  // Whether the backend returns every span attribute inline (G-Research custom API) or only
+  // the selected ones (standard Tempo). Detected from the first search response and used by
+  // the span detail panel to decide whether it must fetch attributes separately.
+  const attributesInlineRef = React.useRef(false);
   // Keep track of the open/collapsed items in a map
   // filter accordingly in the virtualizer
 
@@ -217,11 +216,15 @@ function TraceDetail({
         setLoadingMessage('Loading root nodes of trace');
         const start = mkUnixEpochFromMiliseconds(startTimeInMs);
         const end = mkUnixEpochFromMiliseconds(startTimeInMs + durationInMs);
-        const pipeSelect = getPipeSelect(supportsChildCount);
         const q = `{ trace:id = "${traceId}" && nestedSetParent = -1 } ${pipeSelect}`;
         const data = await search(fetchFn, q, start, end);
+        // Detect once whether this backend returns all attributes inline (used by the span
+        // detail panel). The root spans are representative of the backend's response shape.
+        const rootSpans =
+          data.traces?.find((t) => t.traceID === traceId)?.spanSets?.flatMap((s) => s.spans || []) || [];
+        attributesInlineRef.current = backendReturnsAttributesInline(rootSpans);
         // We pass in hasMore: false because we are fetching the first round of children later.
-        const spans: SpanInfo[] = await extractSpans(fetchFn, idToLevelMap.current, traceId, data);
+        const spans: SpanInfo[] = extractSpans(idToLevelMap.current, traceId, data);
 
         // We fetch the first round of children for each span.
         let isSingleRootSpan = spans.filter((s) => s.level === 0).length === 1;
@@ -239,7 +242,7 @@ function TraceDetail({
           }
           allSpans.push(span);
           if (!hasNoChildren) {
-            const moreSpans = await loadMoreSpans(fetchFn, traceId, idToLevelMap.current, span, supportsChildCount);
+            const moreSpans = await loadMoreSpans(fetchFn, traceId, idToLevelMap.current, span);
             allSpans.push(...moreSpans);
           }
         }
@@ -334,7 +337,7 @@ function TraceDetail({
     });
 
     // Load the children
-    const spans = await loadMoreSpans(fetchFn, traceId, idToLevelMap.current, span, supportsChildCount);
+    const spans = await loadMoreSpans(fetchFn, traceId, idToLevelMap.current, span);
 
     // Update the parent span to show children
     queryClient.setQueryData<SpanInfo[]>(queryKey, (oldData) => {
@@ -530,7 +533,7 @@ function TraceDetail({
               setSelectedSpanElementYOffset(null);
             }}
             fetchFn={fetchFn}
-            supportsChildCount={supportsChildCount}
+            attributesInline={attributesInlineRef.current}
           />
         )}
       </SpanOverlayDrawer>

--- a/src/components/TraceViewerPanel.tsx
+++ b/src/components/TraceViewerPanel.tsx
@@ -56,7 +56,7 @@ function extractQueries(data: PanelData): QueryInfo[] {
   return queries;
 }
 
-export const TraceViewerPanel: React.FC<Props> = ({ options, data, width, height, fieldConfig, id, timeRange }) => {
+export const TraceViewerPanel: React.FC<Props> = ({ data, width, height, fieldConfig, id, timeRange }) => {
   const [showHelpModal, setShowHelpModal] = React.useState(false);
   const [helpModalType, setHelpModalType] = React.useState<'panel-too-small' | 'no-data'>('panel-too-small');
 
@@ -153,7 +153,6 @@ export const TraceViewerPanel: React.FC<Props> = ({ options, data, width, height
         // Grafana adds padding-block of 8px
         panelHeight={height + 16}
         timeRange={timeRange}
-        supportsChildCount={options.supportsChildCount ?? false}
       />
     </QueryClientProvider>
   );

--- a/src/module.ts
+++ b/src/module.ts
@@ -3,17 +3,8 @@ import { TraceViewerPanel } from './components/TraceViewerPanel';
 import './styles/tailwind.css';
 import { PanelOptions } from './types';
 
-// Allow setting default value via environment variable for local development
-// Default is true (child count enabled). Set SUPPORTS_CHILD_COUNT=0 to disable.
-// Usage: SUPPORTS_CHILD_COUNT=0 bun run dev
-// Note: webpack DefinePlugin replaces process.env.SUPPORTS_CHILD_COUNT with a boolean literal (true or false)
-const defaultSupportsChildCount = process.env.SUPPORTS_CHILD_COUNT as unknown as boolean;
-
-export const plugin = new PanelPlugin<PanelOptions>(TraceViewerPanel).setPanelOptions((builder) => {
-  return builder.addBooleanSwitch({
-    path: 'supportsChildCount',
-    name: 'Enable G-Research Tempo API support',
-    description: 'Enable child count support for G-Research custom Tempo API. Disable for standard Grafana Tempo API.',
-    defaultValue: defaultSupportsChildCount, // Default is true (child count enabled)
-  });
-});
+// The plugin works against both standard Grafana Tempo (>= 2.10, vParquet5) and the
+// G-Research custom Tempo API without any user-facing configuration: child counts are
+// requested inline via the `span:childCount` intrinsic and the backend's attribute shape
+// is detected at runtime. Hence there are no panel options to register.
+export const plugin = new PanelPlugin<PanelOptions>(TraceViewerPanel);

--- a/src/types.ts
+++ b/src/types.ts
@@ -42,6 +42,6 @@ export type TraceViewerHeaderProps = {
   timelineOffset: number;
 };
 
-export type PanelOptions = {
-  supportsChildCount: boolean;
-};
+// The plugin no longer exposes any panel options: child-count and inline-attribute support
+// are both detected at runtime instead of toggled by the user.
+export type PanelOptions = Record<string, never>;

--- a/tempo-config.yaml
+++ b/tempo-config.yaml
@@ -28,6 +28,10 @@ storage:
     backend: local
     local:
       path: /tmp/tempo/blocks
+    wal:
+      version: vParquet5
+    block:
+      version: vParquet5
 
 compactor:
   compaction:

--- a/tests/test-trace.json
+++ b/tests/test-trace.json
@@ -448,7 +448,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -522,7 +522,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -596,7 +596,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -676,7 +676,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -744,7 +744,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "5"
               }
@@ -812,7 +812,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -892,7 +892,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -966,7 +966,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1046,7 +1046,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "1"
               }
@@ -1126,7 +1126,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1194,7 +1194,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "4"
               }
@@ -1274,7 +1274,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1360,7 +1360,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1434,7 +1434,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "3"
               }
@@ -1514,7 +1514,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1600,7 +1600,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1680,7 +1680,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1748,7 +1748,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "5"
               }
@@ -1828,7 +1828,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1908,7 +1908,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -1976,7 +1976,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "4"
               }
@@ -2044,7 +2044,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -2124,7 +2124,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -2234,7 +2234,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -2308,7 +2308,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "3"
               }
@@ -2382,7 +2382,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -2462,7 +2462,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "0"
               }
@@ -2542,7 +2542,7 @@
               }
             },
             {
-              "key": "childCount",
+              "key": "span:childCount",
               "value": {
                 "intValue": "2"
               }


### PR DESCRIPTION
Migrate child-count retrieval to Tempo's span:childCount TraceQL intrinsic. The plugin now always selects span:childCount and reads the count inline, which requires Grafana Tempo >= 2.10 on vParquet5 (or the G-Research custom Tempo API, which now returns the same value). The old bare childCount select is a syntax error on Tempo >= 2.10, so this also fixes that breakage. The per-span count() fallback is removed.

Collapse the dual-mode design into a single build with no panel option. Child counts are requested inline, and whether the backend returns all attributes inline (G-Research) or only the selected ones (standard Tempo) is now detected at runtime instead of toggled via "Enable G-Research Tempo API support". This removes the supportsChildCount
panel option, the SUPPORTS_CHILD_COUNT build variable, and the build:without-child-count / dev:without-child-count scripts; CI now runs one build against both stacks.

Move the dev Tempo to vParquet5, bump the version to 0.4.0, and update the README/CHANGELOG accordingly.