### PR TITLE
Add React jsx-runtime to externals

### DIFF
--- a/.config/webpack/webpack.config.ts
+++ b/.config/webpack/webpack.config.ts
@@ -69,6 +69,8 @@ const config = async (env: Env): Promise<Configuration> => {
       '@grafana/slate-react',
       'react',
       'react-dom',
+      'react/jsx-runtime',
+      'react/jsx-dev-runtime',
       'react-redux',
       'redux',
       'rxjs',

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
       # nightly are unaffected, so this is a Grafana regression, not a plugin issue. We skip
       # only that exact patch; this is self-healing — once 13.0.3 is the latest 13.0.x patch,
       # 13.0.2 no longer appears and this filter becomes a no-op. Does not touch plugin.json's
-      # grafanaDependency (>=11.0.0), since the plugin itself runs fine on 13.0.2.
+      # grafanaDependency (>=11.6.14), since the plugin itself runs fine on 13.0.2.
       - name: Drop known-broken Grafana patches from the e2e matrix
         id: filter-versions
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [Unreleased]
+
+### Fixed
+
+- Fixed the panel failing to load on Grafana 13 / React 19 (`TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')`). The bundled `react/jsx-runtime` (React 18) reached for internals that React 19 removed; it is now externalized so the plugin uses the host Grafana's shared `react/jsx-runtime`.
+
+### Changed
+
+- Raised the minimum supported Grafana version to **11.6.14** (`grafanaDependency` `>=11.6.14`). Grafana only exposes `react/jsx-runtime` as a shared SystemJS module from ~11.5 onward, so externalizing it requires this floor. Grafana 11.0–11.4 are no longer supported.
+
 ## [0.4.0] - 2026-06-02
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ There are no panel options to configure — just add the panel and point it at a
    bun run server
 
    # If you wish to start a certain Grafana version. If not specified will use latest by default
-   GRAFANA_VERSION=11.3.0 bun run server
+   GRAFANA_VERSION=11.6.14 bun run server
 
    # Starts the tests
    bun run e2e

--- a/src/plugin.json
+++ b/src/plugin.json
@@ -19,7 +19,7 @@
     "updated": "%TODAY%"
   },
   "dependencies": {
-    "grafanaDependency": ">=11.0.0",
+    "grafanaDependency": ">=11.6.14",
     "plugins": []
   }
 }


### PR DESCRIPTION
## What

Fix the panel failing to load on Grafana 13+ (React 19) and set the minimum supported Grafana version to 11.6.14.

CI is green on this branch now.

## Why

On Grafana 13 the panel did not load at all. The console showed:

```
Error: Could not load plugin
Caused by: TypeError: Cannot read properties of undefined (reading 'ReactCurrentOwner')
  at react-jsx-runtime.production.min.js
  at TraceViewerPanel.tsx:155
```

Root cause: `react` and `react-dom` were externalized in the webpack config, but `react/jsx-runtime` was not, so a copy of React 18's jsx-runtime got bundled into `dist/module.js`. That bundled runtime reads `ReactCurrentOwner` from React internals, which React 19 removed. Grafana 11/12 ship React 18 (so it worked), Grafana 13 ships React 19 (so it crashed). This explains why 11.x/12.x passed and 13.1.0 + nightly failed.

## How

- Externalize `react/jsx-runtime` and `react/jsx-dev-runtime` in `.config/webpack/webpack.config.ts` so the plugin uses the host Grafana's shared runtime instead of bundling its own.
- Raise `grafanaDependency` to `>=11.6.14` in `src/plugin.json`. Grafana only exposes `react/jsx-runtime` as a shared SystemJS module from around 11.5 onward, so on 11.0 to 11.4 the externalized import 404s and the panel fails to load. 11.6.14 is our internal floor. The e2e matrix is derived from `grafanaDependency`, so this drops 11.0.11 and 11.2.10 from CI automatically.
- Update `CHANGELOG.md` (Unreleased), bump the README dev example off the now unsupported 11.3.0, and refresh the stale `grafanaDependency` value in the 13.0.2 skip comment in `ci.yml`.

## Testing

- Reproduced the original failure locally on Grafana 13.1.0, confirmed the `ReactCurrentOwner` load error.
- Verified the externals fix locally: panel loads on 13.1.0.
- Verified the 11.x regression and resolution: externalizing alone 404s on 11.2.10 (no shared jsx-runtime), which is why the floor is raised to a version that has it (11.6.x passes).
- CI is green across the resolved matrix: 11.6.16, 12.3.8, 13.1.0, nightly.

## Notes / caveats

- Breaking change: Grafana 11.0 to 11.4 are no longer supported. I verified this is okay internally.
- The 13.0.2 skip in `ci.yml` stays. It is a separate Grafana regression (the `#grafana-portal-container` overlay intercepts pointer events, so click based tests time out), not related to this fix. Verified locally: on 13.0.2 the plugin loads fine but 15 click based e2e tests still fail on the overlay. The filter is currently a no-op since 13.0.2 is no longer the latest 13.0.x patch, but it is kept as a guard and as documentation.